### PR TITLE
Implement Certificate Authentication for Graphman Client

### DIFF
--- a/graphman-client/README.md
+++ b/graphman-client/README.md
@@ -62,16 +62,16 @@ If you wish to authenticate using a certificate provide the following values in 
 {
   "sourceGateway": {
     "address": "https://fl683674-dev-02.apim.broadcom.net:8443/graphman",
-    "certificateCertName": "authentication-certificate.pem",
-    "certificateKeyName": "authentication-certificate.key",
+    "certFilename": "authentication-certificate.pem",
+    "keyFilename": "authentication-certificate.key",
     "rejectUnauthorized": false,
     "passphrase": "7layer"
   },
 
   "targetGateway": {
     "address": "https://fl683674-dev-02.apim.broadcom.net:6443/graphman",
-    "certificateCertName": "authentication-certificate.pem",
-    "certificateKeyName": "authentication-certificate.key",
+    "certFilename": "authentication-certificate.pem",
+    "keyFilename": "authentication-certificate.key",
     "rejectUnauthorized": false,
     "passphrase": "7layer"
   }

--- a/graphman-client/README.md
+++ b/graphman-client/README.md
@@ -57,6 +57,27 @@ example:
 }
 ```
 
+If you wish to authenticate using a certificate provide the following values in the file graphman.configuration:
+```
+{
+  "sourceGateway": {
+    "address": "https://fl683674-dev-02.apim.broadcom.net:8443/graphman",
+    "certificateCertName": "authentication-certificate.pem",
+    "certificateKeyName": "authentication-certificate.key",
+    "rejectUnauthorized": false,
+    "passphrase": "7layer"
+  },
+
+  "targetGateway": {
+    "address": "https://fl683674-dev-02.apim.broadcom.net:6443/graphman",
+    "certificateCertName": "authentication-certificate.pem",
+    "certificateKeyName": "authentication-certificate.key",
+    "rejectUnauthorized": false,
+    "passphrase": "7layer"
+  }
+}
+```
+
 You are now ready to start using Graphman. To bundle the entire configuration of the source gateway, run the
 following command:
 ```

--- a/graphman-client/graphman.configuration.certificate.example
+++ b/graphman-client/graphman.configuration.certificate.example
@@ -1,16 +1,16 @@
 {
   "sourceGateway": {
     "address": "https://localhost:8443/graphman",
-    "certificateCertName": "authentication-certificate.pem",
-    "certificateKeyName": "authentication-certificate.key",
+    "certFilename": "authentication-certificate.pem",
+    "keyFilename": "authentication-certificate.key",
     "rejectUnauthorized": false,
     "passphrase": "7layer"
   },
 
   "targetGateway": {
     "address": "https://localhost:8443/graphman",
-    "certificateCertName": "authentication-certificate.pem",
-    "certificateKeyName": "authentication-certificate.key",
+    "certFilename": "authentication-certificate.pem",
+    "keyFilename": "authentication-certificate.key",
     "rejectUnauthorized": false,
     "passphrase": "7layer"
   }

--- a/graphman-client/graphman.configuration.certificate.example
+++ b/graphman-client/graphman.configuration.certificate.example
@@ -1,0 +1,17 @@
+{
+  "sourceGateway": {
+    "address": "https://localhost:8443/graphman",
+    "certificateCertName": "authentication-certificate.pem",
+    "certificateKeyName": "authentication-certificate.key",
+    "rejectUnauthorized": false,
+    "passphrase": "7layer"
+  },
+
+  "targetGateway": {
+    "address": "https://localhost:8443/graphman",
+    "certificateCertName": "authentication-certificate.pem",
+    "certificateKeyName": "authentication-certificate.key",
+    "rejectUnauthorized": false,
+    "passphrase": "7layer"
+  }
+}

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -70,7 +70,7 @@ module.exports = {
     invoke: function (options, callback) {
         PRE_REQUEST_EXTN.call(options);
         const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function (response) {
-            let respInfo = { initialized: false, chunks: [] };
+            let respInfo = {initialized: false, chunks: []};
 
             response.on('data', function (chunk) {
                 if (!respInfo.initialized) {

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -62,7 +62,7 @@ module.exports = {
 
     invoke: function (options, callback) {
         PRE_REQUEST_EXTN.call(options);
-        const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function (response) {
+        const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function(response) {
             let respInfo = {initialized: false, chunks: []};
 
             response.on('data', function (chunk) {

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -48,14 +48,12 @@ module.exports = {
 
         if (gateway.username && gateway.password) {
             req.auth = gateway.username + ":" + gateway.password;
-        }
-        else if (gateway.keyFilename && gateway.certFilename) {
+        } else if (gateway.keyFilename && gateway.certFilename) {
             // This expects the certificate.pem and certificate.key file(s) to be in the graphman-client directory. 
             req.key = utils.readFileBinary(`${__dirname}/../${gateway.keyFilename}`);
             req.cert = utils.readFileBinary(`${__dirname}/../${gateway.certFilename}`);
-        }
-        else {
-            throw new Error("Either username/password or certificate authentication must be configured. Please provide the following values: \n 'Username/Password Authentication: the username and password fields' \n 'Certificate Authentication: keyFilename and certFilename fields'.");
+        } else {
+            throw new Error("Authentication details are missing. Please provide either basic authentication (username/password) or mTLS based authentication (keyFilename/certFilename)");
         }
 
         req.minVersion = req.maxVersion = gateway.tlsProtocol || "TLSv1.2";
@@ -64,8 +62,8 @@ module.exports = {
 
     invoke: function (options, callback) {
         PRE_REQUEST_EXTN.call(options);
-        const req = ((!options.protocol || options.protocol === 'https' || options.protocol === 'https:') ? https : http).request(options, function (response) {
-            let respInfo = { initialized: false, chunks: [] };
+        const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function (response) {
+            let respInfo = {initialized: false, chunks: []};
 
             response.on('data', function (chunk) {
                 if (!respInfo.initialized) {
@@ -94,7 +92,7 @@ module.exports = {
                 } else {
                     utils.info("unexpected graphman http response");
                     utils.info(data);
-                    callback({ error: data, data: {} });
+                    callback({error: data, data: {}});
                 }
             });
         });

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -47,7 +47,6 @@ module.exports = {
             body: body || {}
         };
         
-        
         const isUsernamePasswordAuthentication = gateway.username && gateway.password
         const isCertificateAuthentication = gateway.certificateKeyName && gateway.certificateCertName
 

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -68,7 +68,7 @@ module.exports = {
 
     invoke: function (options, callback) {
         PRE_REQUEST_EXTN.call(options);
-        const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function (response) {
+        const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function(response) {
             let respInfo = {initialized: false, chunks: []};
 
             response.on('data', function (chunk) {

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -69,7 +69,7 @@ module.exports = {
 
     invoke: function (options, callback) {
         PRE_REQUEST_EXTN.call(options);
-        const req = ((!options.protocol || options.protocol === 'https' || options.protocol === 'https:') ? https : http).request(options, function (response) {
+        const req = ((!options.protocol||options.protocol === 'https'||options.protocol === 'https:') ? https : http).request(options, function (response) {
             let respInfo = { initialized: false, chunks: [] };
 
             response.on('data', function (chunk) {
@@ -99,7 +99,7 @@ module.exports = {
                 } else {
                     utils.info("unexpected graphman http response");
                     utils.info(data);
-                    callback({ error: data, data: {} });
+                    callback({error: data, data: {}});
                 }
             });
         });

--- a/graphman-client/modules/help.js
+++ b/graphman-client/modules/help.js
@@ -23,7 +23,7 @@ module.exports = {
         console.log("        # address - a valid graphman url. Default is https://localhost:8443/graphman");
         console.log("        # username - gateway user for administration.");
         console.log("        # password - gateway user's password for administration.");
-        console.log("        # certificateCertName - gateway user certificate certificate used for authentication.");
+        console.log("        # certFilename - gateway user certificate certificate used for authentication.");
         console.log("        # certificateCertKey - gateway user certificate key used for authentication.");
         console.log("        # passphrase - encryption passphrase used to encode/decode the secrets in the bundles.");
         console.log("        # rejectUnauthorized - use this boolean flag whether to trust the gateway server certificate without verification.");

--- a/graphman-client/modules/help.js
+++ b/graphman-client/modules/help.js
@@ -23,8 +23,8 @@ module.exports = {
         console.log("        # address - a valid graphman url. Default is https://localhost:8443/graphman");
         console.log("        # username - gateway user for administration.");
         console.log("        # password - gateway user's password for administration.");
-        console.log("        # certFilename - gateway user certificate certificate used for authentication.");
-        console.log("        # certificateCertKey - gateway user certificate key used for authentication.");
+        console.log("        # certFilename - user's certificate for authentication.");
+        console.log("        # certFilename - user's certificate for authentication.");
         console.log("        # passphrase - encryption passphrase used to encode/decode the secrets in the bundles.");
         console.log("        # rejectUnauthorized - use this boolean flag whether to trust the gateway server certificate without verification.");
         console.log("      --targetGateway.*");

--- a/graphman-client/modules/help.js
+++ b/graphman-client/modules/help.js
@@ -23,6 +23,8 @@ module.exports = {
         console.log("        # address - a valid graphman url. Default is https://localhost:8443/graphman");
         console.log("        # username - gateway user for administration.");
         console.log("        # password - gateway user's password for administration.");
+        console.log("        # certificateCertName - gateway user certificate certificate used for authentication.");
+        console.log("        # certificateCertKey - gateway user certificate key used for authentication.");
         console.log("        # passphrase - encryption passphrase used to encode/decode the secrets in the bundles.");
         console.log("        # rejectUnauthorized - use this boolean flag whether to trust the gateway server certificate without verification.");
         console.log("      --targetGateway.*");


### PR DESCRIPTION
Currently provisioning resources to the API gateway using Graphman does not support Certificate Authentication. We had received the Alpha/Experimental version of the grapman-client earlier this year and had implemented this way of authentication by certificate so our pipelines can securely deploy resources to our gateway.

Since we wanted to upgrade to the community client we decided it would be fair to try to get our changes implemented into this version so that we won't have to manually change the file(s) when downloading newer versions of the client.

# Changes
* Implemented authentication using a certificate public key and private key
  * Client expects the public and private key to be present in the graphman-client directory
  * Added example file for certificate authentication