### PR TITLE
NORALLY: support for multiple versioned schemas

### DIFF
--- a/graphman-client/modules/graphman-bundle.js
+++ b/graphman-client/modules/graphman-bundle.js
@@ -1,6 +1,6 @@
 
 const utils = require("./graphman-utils");
-const SCHEMA_METADATA = require("./graphql-schema").metadata();
+const SCHEMA_METADATA = require("./graphman").schemaMetadata();
 const GOID_PLURAL_METHODS = ["fipUsers", "internalUsers", "fipGroups", "internalGroups", "ldaps", "fips", "trustedCerts"];
 module.exports = {
     EXPORT_USE: 'export',

--- a/graphman-client/modules/graphman-operation-renew.js
+++ b/graphman-client/modules/graphman-operation-renew.js
@@ -4,7 +4,7 @@ const butils = require("./graphman-bundle");
 const queryBuilder = require("./graphql-query-builder");
 const opExport = require("./graphman-operation-export");
 const graphman = require("./graphman");
-const SCHEMA_METADATA = require("./graphql-schema").metadata();
+const SCHEMA_METADATA = graphman.schemaMetadata();
 
 module.exports = {
     run: function (params) {

--- a/graphman-client/modules/graphman-operation-schema.js
+++ b/graphman-client/modules/graphman-operation-schema.js
@@ -1,8 +1,12 @@
 
+const utils = require("./graphman-utils");
+const graphman = require("./graphman");
+
 module.exports = {
     run: function (params) {
         if (params.refresh) {
-            require("./graphql-schema").refresh();
+            graphman.refreshSchemaMetadata();
+            utils.info("pre-compiled schema is refreshed");
         }
     },
 

--- a/graphman-client/modules/graphman-utils.js
+++ b/graphman-client/modules/graphman-utils.js
@@ -46,11 +46,6 @@ module.exports = {
     },
 
     schemaDir: function (schemaVersion) {
-        if (schemaVersion) {
-            const path = this.path(SCHEMA_DIR, schemaVersion);
-            return this.existsFile(path) ? path : SCHEMA_DIR;
-        }
-
         return SCHEMA_DIR;
     },
 

--- a/graphman-client/modules/graphman-utils.js
+++ b/graphman-client/modules/graphman-utils.js
@@ -46,6 +46,11 @@ module.exports = {
     },
 
     schemaDir: function (schemaVersion) {
+        if (schemaVersion) {
+            const path = this.path(SCHEMA_DIR, schemaVersion);
+            return this.existsFile(path) ? path : SCHEMA_DIR;
+        }
+
         return SCHEMA_DIR;
     },
 

--- a/graphman-client/modules/graphman-utils.js
+++ b/graphman-client/modules/graphman-utils.js
@@ -3,6 +3,11 @@ const fs = require("fs");
 const putil = require("path");
 const HOME_DIR = process.env.GRAPHMAN_HOME;
 const MODULES_DIR = HOME_DIR + "/modules";
+const QUERIES_DIR = HOME_DIR + "/queries";
+const SCHEMA_DIR = HOME_DIR + "/schema";
+const SCHEMA_METADATA_BASE_FILE = "metadata-base.json";
+const SCHEMA_METADATA_FILE = "metadata.json";
+
 const NONE_LEVEL = 0;
 const WARN_LEVEL = 1;
 const INFO_LEVEL = 2;
@@ -34,6 +39,36 @@ module.exports = {
 
     home: function () {
         return HOME_DIR;
+    },
+
+    modulesDir: function () {
+        return MODULES_DIR;
+    },
+
+    schemaDir: function (schemaVersion) {
+        if (schemaVersion) {
+            const path = this.path(SCHEMA_DIR, schemaVersion);
+            return this.existsFile(path) ? path : SCHEMA_DIR;
+        }
+
+        return SCHEMA_DIR;
+    },
+
+    schemaMetadataBaseFile: function (schemaVersion) {
+        return this.path(this.schemaDir(schemaVersion), SCHEMA_METADATA_BASE_FILE);
+    },
+
+    schemaMetadataFile: function (schemaVersion) {
+        return this.path(this.schemaDir(schemaVersion), SCHEMA_METADATA_FILE);
+    },
+
+    queriesDir: function (schemaVersion) {
+        if (schemaVersion) {
+            const path = this.path(QUERIES_DIR, schemaVersion);
+            return this.existsFile(path) ? path : QUERIES_DIR;
+        }
+
+        return QUERIES_DIR;
     },
 
     isDirectory: function (fd) {

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -27,7 +27,7 @@ module.exports = {
         }
 
         config.version = VERSION;
-        config.schemaVersion = params.schemaVersion || SCHEMA_VERSION;
+        config.schemaVersion = params.schemaVersion || config.schemaVersion || SCHEMA_VERSION;
         if (config.schemaVersion !== SCHEMA_VERSION) {
             if (utils.schemaDir(config.schemaVersion) === utils.schemaDir()) {
                 utils.warn(`specified schema (${config.schemaVersion}) is missing, falling back to the default`);

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -30,6 +30,9 @@ module.exports = {
         config.defaultSchemaVersion = SCHEMA_VERSION;
         config.schemaVersion = params.schemaVersion || config.schemaVersion || SCHEMA_VERSION;
         if (config.schemaVersion !== SCHEMA_VERSION) {
+            if (utils.schemaDir(config.schemaVersion) === utils.schemaDir()) {
+                utils.warn(`specified schema (${config.schemaVersion}) is missing, falling back to the default`);
+            }
             if (utils.queriesDir(config.schemaVersion) === utils.queriesDir()) {
                 utils.warn(`specified schema (${config.schemaVersion}) queries are missing, falling back to the default`);
             }

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -28,6 +28,12 @@ module.exports = {
 
         config.version = VERSION;
         config.schemaVersion = params.schemaVersion || SCHEMA_VERSION;
+        if (config.schemaVersion !== SCHEMA_VERSION) {
+            if (utils.schemaDir(config.schemaVersion) === utils.schemaDir()) {
+                utils.warn(`specified schema (${config.schemaVersion}) is missing, falling back to the default`);
+            }
+        }
+
         this.metadata = gqlschema.build(config.schemaVersion, false);
         this.loadedConfig = config;
     },

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -1,9 +1,10 @@
 
+const VERSION = "v1.0";
+const SCHEMA_VERSION = "v10.1.CR03";
+
 const utils = require("./graphman-utils");
 const hutils = require("./http-utils");
 const gqlschema = require("./graphql-schema");
-const VERSION = "v1.0";
-const SCHEMA_VERSION = VERSION;
 
 const PRE_REQUEST_EXTN = utils.extension("graphman-pre-request");
 const PRE_RESPONSE_EXTN = utils.extension("graphman-pre-response");

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -1,6 +1,6 @@
 
 const VERSION = "v1.0";
-const SCHEMA_VERSION = "v10.1.CR03";
+const SCHEMA_VERSION = "v10.1-CR03";
 
 const utils = require("./graphman-utils");
 const hutils = require("./http-utils");
@@ -27,10 +27,11 @@ module.exports = {
         }
 
         config.version = VERSION;
+        config.defaultSchemaVersion = SCHEMA_VERSION;
         config.schemaVersion = params.schemaVersion || config.schemaVersion || SCHEMA_VERSION;
         if (config.schemaVersion !== SCHEMA_VERSION) {
-            if (utils.schemaDir(config.schemaVersion) === utils.schemaDir()) {
-                utils.warn(`specified schema (${config.schemaVersion}) is missing, falling back to the default`);
+            if (utils.queriesDir(config.schemaVersion) === utils.queriesDir()) {
+                utils.warn(`specified schema (${config.schemaVersion}) queries are missing, falling back to the default`);
             }
         }
 

--- a/graphman-client/modules/graphql-query-builder.js
+++ b/graphman-client/modules/graphql-query-builder.js
@@ -19,8 +19,8 @@ If <suffix> is not used, type reference will be expanded to the fields.
 NOTE: type reference can refer other type references. But, ensure it doesn't end up recursive infinite loop.
  */
 const utils = require("./graphman-utils");
-const QUERIES_DIR = utils.home() + "/queries";
-const SCHEMA_METADATA = require("./graphql-schema").metadata();
+const SCHEMA_METADATA = require("./graphman").schemaMetadata();
+const QUERIES_DIR = utils.queriesDir(SCHEMA_METADATA.schemaVersion);
 
 module.exports = {
     build: function (queryId, variables) {

--- a/graphman-client/modules/graphql-query-builder.js
+++ b/graphman-client/modules/graphql-query-builder.js
@@ -19,8 +19,9 @@ If <suffix> is not used, type reference will be expanded to the fields.
 NOTE: type reference can refer other type references. But, ensure it doesn't end up recursive infinite loop.
  */
 const utils = require("./graphman-utils");
-const SCHEMA_METADATA = require("./graphman").schemaMetadata();
-const QUERIES_DIR = utils.queriesDir(SCHEMA_METADATA.schemaVersion);
+const graphman = require("./graphman");
+const SCHEMA_METADATA = graphman.schemaMetadata();
+const QUERIES_DIR = utils.queriesDir(graphman.configuration().schemaVersion);
 
 module.exports = {
     build: function (queryId, variables) {

--- a/graphman-client/modules/help.js
+++ b/graphman-client/modules/help.js
@@ -5,7 +5,7 @@ const graphman = require("./graphman");
 module.exports = {
     run: function (params, supportedOperations) {
         const config = graphman.configuration();
-        console.log("graphman " + config.version + (config.version !== config.schemaVersion ? ` [schemaVersion=${config.schemaVersion}]`: ""));
+        console.log("graphman " + config.version + (` [schemaVersion=${config.schemaVersion}]`));
         console.log("usage:");
         if (params.operation && supportedOperations.includes(params.operation)) {
             require(GRAPHMAN_OPERATION_MODULE_PREFIX + params.operation).usage();

--- a/graphman-client/modules/help.js
+++ b/graphman-client/modules/help.js
@@ -1,10 +1,11 @@
 
 const GRAPHMAN_OPERATION_MODULE_PREFIX = "./graphman-operation-";
-const SCHEMA_METADATA = require("./graphql-schema").metadata();
+const graphman = require("./graphman");
 
 module.exports = {
     run: function (params, supportedOperations) {
-        console.log("graphman v1.0");
+        const config = graphman.configuration();
+        console.log("graphman " + config.version + (config.version !== config.schemaVersion ? ` [schemaVersion=${config.schemaVersion}]`: ""));
         console.log("usage:");
         if (params.operation && supportedOperations.includes(params.operation)) {
             require(GRAPHMAN_OPERATION_MODULE_PREFIX + params.operation).usage();
@@ -33,8 +34,9 @@ module.exports = {
 
         console.log();
         console.log("    NOTE: Often, entity types are referred in their plural form. Choose one from the below table for <entity-type-plural-tag>. And, the list goes as below:");
-        Object.keys(SCHEMA_METADATA.types).sort().forEach(key => {
-            let value = SCHEMA_METADATA.types[key];
+        const schemaMetadata = graphman.schemaMetadata();
+        Object.keys(schemaMetadata.types).sort().forEach(key => {
+            let value = schemaMetadata.types[key];
             if (value && value.pluralMethod) console.log(`        # ${key} - ${value.pluralMethod}`);
         });
     }

--- a/graphman-client/modules/help.js
+++ b/graphman-client/modules/help.js
@@ -9,6 +9,7 @@ module.exports = {
         console.log("usage:");
         if (params.operation && supportedOperations.includes(params.operation)) {
             require(GRAPHMAN_OPERATION_MODULE_PREFIX + params.operation).usage();
+            return;
         } else {
             supportedOperations.forEach(item => {
                 require(GRAPHMAN_OPERATION_MODULE_PREFIX + item).usage();

--- a/graphman-client/modules/main.js
+++ b/graphman-client/modules/main.js
@@ -5,11 +5,16 @@ const GRAPHMAN_OPERATION_MODULE_PREFIX = "./graphman-operation-";
 const args = process.argv.slice(2);
 const op = args[0];
 const utils = require("./graphman-utils");
+const graphman = require("./graphman");
+
 try {
     init();
 
     const params = parse(args);
     utils.logAt(params.log);
+
+    // initialize configuration and schema metadata
+    graphman.init(params);
 
     if (!op || op === "help") {
         require("./help").run(params, SUPPORTED_OPERATIONS);


### PR DESCRIPTION
With these changes, graphman-client can work with multiple versioned graphql schemas.
- Schema version is loosely coupled with the graphman-client version.
- Schema version can be parameterized at CLI. (i.e., **_--schemaVersion_** <schema-version>) or 
- Schema version can be specified in the graphman configuration file

Currently, folders that require the schema version aware
- queries
- schema

Users can keep multiple versions of queries in the sub-folders. For example:
- schema/v10.1-CR03
- queries/v10.1-CR03
- queries/v11.0-CR01

If the specified schema folder is missing, client will fall back to the default one (i.e., located in the top-level folder).
