### PR TITLE
NORALLY: v11.0 CR01 support

### DIFF
--- a/graphman-client/.gitignore
+++ b/graphman-client/.gitignore
@@ -7,4 +7,5 @@ target.properties
 ./*.xml
 ./*.zip
 schema/metadata.json
+schema/**/metadata.json
 output/*

--- a/graphman-client/README.md
+++ b/graphman-client/README.md
@@ -40,7 +40,7 @@ example:
 ```
 {
   "sourceGateway": {
-    "address": "https://fl683674-dev-02.apim.broadcom.net:8443/graphman",
+    "address": "https://some-source-gateway:8443/graphman",
     "username": "admin",
     "password": "7layer",
     "rejectUnauthorized": false,
@@ -48,7 +48,7 @@ example:
   },
 
   "targetGateway": {
-    "address": "https://fl683674-dev-02.apim.broadcom.net:6443/graphman",
+    "address": "https://some-target-gateway:8443/graphman",
     "username": "admin",
     "password": "7layer",
     "rejectUnauthorized": false,
@@ -61,7 +61,7 @@ If you wish to authenticate using a certificate provide the following values in 
 ```
 {
   "sourceGateway": {
-    "address": "https://fl683674-dev-02.apim.broadcom.net:8443/graphman",
+    "address": "https://some-source-gateway:8443/graphman",
     "certFilename": "authentication-certificate.pem",
     "keyFilename": "authentication-certificate.key",
     "rejectUnauthorized": false,
@@ -69,7 +69,7 @@ If you wish to authenticate using a certificate provide the following values in 
   },
 
   "targetGateway": {
-    "address": "https://fl683674-dev-02.apim.broadcom.net:6443/graphman",
+    "address": "https://some-target-gateway:6443/graphman",
     "certFilename": "authentication-certificate.pem",
     "keyFilename": "authentication-certificate.key",
     "rejectUnauthorized": false,
@@ -92,12 +92,27 @@ You can apply this configuration bundle as-is to the target gateway.
 Congratulations, you just packaged all the configuration from the source gateway, and applied it to the
 target gateway.
 
-```
-NOTE: Use platform specific entrypoint to interact with the GRAPHMAN. 
-Windows - graphman.bat
-Linux - graphman.sh
-```
+> **Note**
+> Use platform specific entrypoint to interact with the GRAPHMAN. 
+> 
+> - Windows - graphman.bat
+> 
+> - Linux - graphman.sh
 
+> **Note**
+> Running GRAPHMAN with no arguments shows the description about the supported operations. Try it out.
+
+> **Warning**
+> Graphman is still under continuous development to extend its support to the gateway entities. 
+> As GraphQL schema is subjected frequent modifications, new or modified queries may not be compatible with the older gateways. 
+> Because of which, CLI is improved to work with multiple schemas. Use configuration file or CLI argument to decide the schema to work with.
+> - "schemaVersion": <schema-version>
+> - --schemaVersion <schema-version>
+> 
+> Supported schemas are:
+> - 11.0-CR01 (default) 
+> - 10.1-CR03
+> 
 ## Graphman configuration bundles <a name="bundles"></a>
 
 Graphman bundles are collections of 0 or more Layer7 Gateway configuration entities. You can combine any

--- a/graphman-client/README.md
+++ b/graphman-client/README.md
@@ -104,7 +104,7 @@ target gateway.
 
 > **Warning**
 > Graphman is still under continuous development to extend its support to the gateway entities. 
-> As GraphQL schema is subjected frequent modifications, new or modified queries may not be compatible with the older gateways. 
+> As GraphQL schema is subjected to the frequent modifications, new or modified queries may not be compatible with the older gateways. 
 > Because of which, CLI is improved to work with multiple schemas. Use configuration file or CLI argument to decide the schema to work with.
 > - "schemaVersion": <schema-version>
 > - --schemaVersion <schema-version>

--- a/graphman-client/modules/graphman-bundle.js
+++ b/graphman-client/modules/graphman-bundle.js
@@ -311,6 +311,11 @@ let importSanitizer = function () {
                 entity.revocationCheckPolicyName = entity.revocationCheckPolicy.name;
                 delete entity.revocationCheckPolicy;
             }
+        } else if (pluralMethod ==="passwordPolicies" || pluralMethod === "serviceResolutionConfigs") {
+            if (entity.checksum) {
+                utils.info(`removing checksum field`);
+                delete entity.checksum;
+            }
         }
     }
 }();

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -29,13 +29,8 @@ module.exports = {
         config.version = VERSION;
         config.defaultSchemaVersion = SCHEMA_VERSION;
         config.schemaVersion = params.schemaVersion || config.schemaVersion || SCHEMA_VERSION;
-        if (config.schemaVersion !== SCHEMA_VERSION) {
-            if (utils.schemaDir(config.schemaVersion) === utils.schemaDir()) {
-                utils.warn(`specified schema (${config.schemaVersion}) is missing, falling back to the default`);
-            }
-            if (utils.queriesDir(config.schemaVersion) === utils.queriesDir()) {
-                utils.warn(`specified schema (${config.schemaVersion}) queries are missing, falling back to the default`);
-            }
+        if (config.schemaVersion !== SCHEMA_VERSION && utils.schemaDir(config.schemaVersion) === utils.schemaDir()) {
+            utils.warn(`specified schema (${config.schemaVersion}) is missing, falling back to the default`);
         }
 
         this.metadata = gqlschema.build(config.schemaVersion, false);

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -1,6 +1,6 @@
 
 const VERSION = "v1.0";
-const SCHEMA_VERSION = "v10.1-CR03";
+const SCHEMA_VERSION = "v11.0-CR01";
 
 const utils = require("./graphman-utils");
 const hutils = require("./http-utils");

--- a/graphman-client/modules/graphql-query-builder.js
+++ b/graphman-client/modules/graphql-query-builder.js
@@ -20,8 +20,13 @@ NOTE: type reference can refer other type references. But, ensure it doesn't end
  */
 const utils = require("./graphman-utils");
 const graphman = require("./graphman");
+const CONFIG = graphman.configuration();
 const SCHEMA_METADATA = graphman.schemaMetadata();
-const QUERIES_DIR = utils.queriesDir(graphman.configuration().schemaVersion);
+const QUERIES_DIR = utils.queriesDir(CONFIG.schemaVersion);
+
+if (CONFIG.defaultSchemaVersion !== CONFIG.schemaVersion && QUERIES_DIR === utils.queriesDir()) {
+    utils.warn(`specified schema (${CONFIG.schemaVersion}) queries are missing, falling back to the default`);
+}
 
 module.exports = {
     build: function (queryId, variables) {

--- a/graphman-client/modules/help.js
+++ b/graphman-client/modules/help.js
@@ -31,7 +31,11 @@ module.exports = {
         console.log("        # rejectUnauthorized - use this boolean flag whether to trust the gateway server certificate without verification.");
         console.log("      --targetGateway.*");
         console.log("        # similar to that of sourceGateway, use any of the above sub-options to override the target gateway value specified in the graphman configuration.");
-        console.log("      --log: to set the log level to one of ['warn', 'info', 'fine', 'debug', 'nolog']. Default is info.");
+        console.log("      --log <level>: to set the log level to one of ['warn', 'info', 'fine', 'debug', 'nolog']. Default is info.");
+        console.log("      --schemaVersion <schema-version>: to specify the schema version to work with gateway's staged at different schemas.");
+        console.log("        # supported schemas:");
+        console.log("          v11.0-CR01 (default)");
+        console.log("          v10.1-CR03");
 
         console.log();
         console.log("    NOTE: Often, entity types are referred in their plural form. Choose one from the below table for <entity-type-plural-tag>. And, the list goes as below:");

--- a/graphman-client/postman/graphman.postman_collection.json
+++ b/graphman-client/postman/graphman.postman_collection.json
@@ -49,6 +49,8 @@
 									"    });\r",
 									"});\r",
 									"if (bundle.internalSoapServices) bundle.internalSoapServices.forEach(item => delete item.resolvers);\r",
+									"if (bundle.serviceResolutionConfigs) bundle.serviceResolutionConfigs.forEach(item => delete item.checksum);\r",
+									"if (bundle.passwordPolicies) bundle.passwordPolicies.forEach(item => delete item.checksum);\r",
 									"\r",
 									"pm.environment.set(\"source_bundle\", JSON.stringify(bundle, null, 2));"
 								],
@@ -62,7 +64,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "mutation applyBundle (\n    $clusterProperties: [ClusterPropertyInput!]!=[],\n    $webApiServices: [WebApiServiceInput!]!=[],\n    $encassConfigs:[EncassConfigInput!]!=[],\n    $trustedCerts:[TrustedCertInput!]!=[],\n    $dtds:[DtdInput!]!=[],\n    $schemas:[SchemaInput!]!=[],\n    $jdbcConnections:[JdbcConnectionInput!]!=[],\n    $soapServices:[SoapServiceInput!]!=[],\n    $policyFragments: [PolicyFragmentInput!]!=[],\n    $fips:[FipInput!]!=[],\n    $ldaps:[LdapInput!]!=[],\n    $fipGroups:[FipGroupInput!]!=[],\n    $internalGroups:[InternalGroupInput!]!=[],\n    $fipUsers:[FipUserInput!]!=[],\n    $internalUsers:[InternalUserInput!]!=[],\n    $keys: [KeyInput!]!=[],\n    $secrets: [SecretInput!]!=[],\n    $cassandraConnections:[CassandraConnectionInput!]!=[],\n    $jmsDestinations:[JmsDestinationInput!]!=[],\n    $internalWebApiServices: [WebApiServiceInput!]!=[],\n    $internalSoapServices:[SoapServiceInput!]!=[],\n    $emailListeners: [EmailListenerInput!]!=[],\n    $listenPorts: [ListenPortInput!]!=[],\n    $activeConnectors: [ActiveConnectorInput!]!=[],\n    $smConfigs: [SMConfigInput!]!=[],\n    $globalPolicies:[GlobalPolicyInput!]!=[],\n    $backgroundTaskPolicies:[BackgroundTaskPolicyInput!]!=[],\n    $scheduledTasks:[ScheduledTaskInput!]!=[],\n    $serverModuleFiles:[ServerModuleFileInput!]!=[]) {\n        setServerModuleFiles(input: $serverModuleFiles){serverModuleFiles{goid} detailedStatus {status description}}\n        setClusterProperties (input: $clusterProperties){clusterProperties {goid} detailedStatus {status description}}\n        setTrustedCerts (input: $trustedCerts){trustedCerts {goid} detailedStatus {status description}}\n        setSecrets (input: $secrets){secrets{name} detailedStatus {status description}}\n        setSchemas (input: $schemas){schemas {goid} detailedStatus {status description}}\n        setDtds (input: $dtds){dtds {goid} detailedStatus {status description}}\n        setJdbcConnections (input: $jdbcConnections){jdbcConnections {goid} detailedStatus {status description}}\n        setFips (input: $fips){fips{goid} detailedStatus {status description}}\n        setLdaps (input: $ldaps){ldaps{goid} detailedStatus {status description}}\n        setFipGroups (input: $fipGroups){fipGroups{goid} detailedStatus {status description}}\n        setInternalGroups (input: $internalGroups){internalGroups{goid} detailedStatus {status description}}\n        setFipUsers (input: $fipUsers){fipUsers{goid} detailedStatus {status description}}\n        setInternalUsers (input: $internalUsers){internalUsers{goid} detailedStatus {status description}}\n        setCassandraConnections (input: $cassandraConnections){cassandraConnections {goid} detailedStatus {status description}}\n        setJmsDestinations (input: $jmsDestinations){jmsDestinations {goid} detailedStatus {status description}}\n        setSMConfigs (input: $smConfigs){smConfigs {goid} detailedStatus {status description}}\n        setPolicyFragments (input: $policyFragments){policyFragments {goid} detailedStatus {status description}}\n        setEncassConfigs (input: $encassConfigs){encassConfigs {goid} detailedStatus {status description}}\n        setGlobalPolicies (input: $globalPolicies){globalPolicies {goid} detailedStatus {status description}}\n        setBackgroundTaskPolicies (input: $backgroundTaskPolicies){backgroundTaskPolicies {goid} detailedStatus {status description}}\n        setWebApiServices (input: $webApiServices){webApiServices {goid} detailedStatus {status description}}\n        setSoapServices (input: $soapServices){soapServices {goid} detailedStatus {status description}}\n        setInternalWebApiServices (input: $internalWebApiServices){internalWebApiServices {goid} detailedStatus {status description}}\n        setInternalSoapServices (input: $internalSoapServices){internalSoapServices {goid} detailedStatus {status description}}\n        setEmailListeners (input: $emailListeners){emailListeners {goid} detailedStatus {status description}}\n        setListenPorts (input: $listenPorts){listenPorts {goid} detailedStatus {status description}}\n        setActiveConnectors (input: $activeConnectors){activeConnectors {goid} detailedStatus {status description}}\n        setScheduledTasks (input: $scheduledTasks){scheduledTasks {goid} detailedStatus {status description}}\n\n        # Keys must be mutated at the end\n        setKeys (input: $keys) {keys {alias} detailedStatus {status description}}\n}\n",
+								"query": "mutation applyBundle (\n    $clusterProperties: [ClusterPropertyInput!]!=[],\n    $webApiServices: [WebApiServiceInput!]!=[],\n    $encassConfigs:[EncassConfigInput!]!=[],\n    $revocationCheckPolicies:[RevocationCheckPolicyInput!]!=[],\n    $trustedCerts:[TrustedCertInput!]!=[],\n    $dtds:[DtdInput!]!=[],\n    $schemas:[SchemaInput!]!=[],\n    $jdbcConnections:[JdbcConnectionInput!]!=[],\n    $soapServices:[SoapServiceInput!]!=[],\n    $policyFragments: [PolicyFragmentInput!]!=[],\n    $fips:[FipInput!]!=[],\n    $ldaps:[LdapInput!]!=[],\n    $fipGroups:[FipGroupInput!]!=[],\n    $internalGroups:[InternalGroupInput!]!=[],\n    $fipUsers:[FipUserInput!]!=[],\n    $internalUsers:[InternalUserInput!]!=[],\n    $keys: [KeyInput!]!=[],\n    $secrets: [SecretInput!]!=[],\n    $cassandraConnections:[CassandraConnectionInput!]!=[],\n    $jmsDestinations:[JmsDestinationInput!]!=[],\n    $emailListeners: [EmailListenerInput!]!=[],\n    $listenPorts: [ListenPortInput!]!=[],\n    $activeConnectors: [ActiveConnectorInput!]!=[],\n    $smConfigs: [SMConfigInput!]!=[],\n    $globalPolicies:[GlobalPolicyInput!]!=[],\n    $backgroundTaskPolicies:[BackgroundTaskPolicyInput!]!=[],\n    $scheduledTasks:[ScheduledTaskInput!]!=[],\n    $internalWebApiServices: [WebApiServiceInput!]!=[],\n    $internalSoapServices:[SoapServiceInput!]!=[],\n    $serverModuleFiles:[ServerModuleFileInput!]!=[],\n    $passwordPolicies:[PasswordPolicyInput!]!=[],\n    $serviceResolutionConfigs:[ServiceResolutionConfigInput!]!=[],\n    $administrativeUserAccountProperties: [AdministrativeUserAccountPropertyInput!]!=[]) {\n    setServerModuleFiles(input: $serverModuleFiles){serverModuleFiles{goid} status}\n    setClusterProperties (input: $clusterProperties){clusterProperties {goid} status}\n    setServiceResolutionConfigs (input: $serviceResolutionConfigs){serviceResolutionConfigs {goid} status}\n    setPasswordPolicies (input: $passwordPolicies){passwordPolicies {goid} status}\n    setAdministrativeUserAccountProperties (input: $administrativeUserAccountProperties){administrativeUserAccountProperties {goid} status}\n    \n    setRevocationCheckPolicies (input: $revocationCheckPolicies){revocationCheckPolicies {goid} status}\n    setTrustedCerts (input: $trustedCerts){trustedCerts {goid} status}\n    setSecrets (input: $secrets){secrets{name} status}\n    setSchemas (input: $schemas){schemas {goid} status}\n    setDtds (input: $dtds){dtds {goid} status}\n    setJdbcConnections (input: $jdbcConnections){jdbcConnections {goid} status}\n    setFips (input: $fips){fips{goid} status}\n    setLdaps (input: $ldaps){ldaps{goid} status}\n    setFipGroups (input: $fipGroups){fipGroups{goid} status}\n    setInternalGroups (input: $internalGroups){internalGroups{goid} status}\n    setFipUsers (input: $fipUsers){fipUsers{goid} status}\n    setInternalUsers (input: $internalUsers){internalUsers{goid} status}\n    setCassandraConnections (input: $cassandraConnections){cassandraConnections {goid} status}\n    setJmsDestinations (input: $jmsDestinations){jmsDestinations {goid} status}\n    setSMConfigs (input: $smConfigs){smConfigs {goid} status}\n    setPolicyFragments (input: $policyFragments){policyFragments {goid} status}\n    setEncassConfigs (input: $encassConfigs){encassConfigs {goid} status}\n    setGlobalPolicies (input: $globalPolicies){globalPolicies {goid} status}\n    setBackgroundTaskPolicies (input: $backgroundTaskPolicies){backgroundTaskPolicies {goid} status}\n    setWebApiServices (input: $webApiServices){webApiServices {goid} status}\n    setSoapServices (input: $soapServices){soapServices {goid} status}\n    setInternalWebApiServices (input: $internalWebApiServices){internalWebApiServices {goid} status}\n    setInternalSoapServices (input: $internalSoapServices){internalSoapServices {goid} status}\n    setEmailListeners (input: $emailListeners){emailListeners {goid} status}\n    setListenPorts (input: $listenPorts){listenPorts {goid} status}\n    setActiveConnectors (input: $activeConnectors){activeConnectors {goid} status}\n    setScheduledTasks (input: $scheduledTasks){scheduledTasks {goid} status}\n\n    # Keys must be mutated at the end\n    setKeys (input: $keys) {keys {alias} status}\n}\n",
 								"variables": "{{source_bundle}}"
 							}
 						},
@@ -101,7 +103,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query policyFragmentByName ($name: String!) {\n    policyFragmentByName (name: $name) {\n        goid\n        guid\n        name\n        checksum\n\n        folderPath\n        soap\n        policy {\n            xml\n            allDependencies {\n                encassConfigs {\n                    goid guid name checksum \n                    description policyName \n                    encassArgs { name type ordinal guiPrompt guiLabel } \n                    encassResults{ name type } \n                    properties { name value }\n                }\n                policyFragments {\n                    goid guid name checksum \n                    folderPath soap \n                    policy { xml }\n                }\n\n                activeConnectors {\n                    goid name checksum \n                    enabled connectorType hardwiredServiceName \n                    properties { name value } \n                    advancedProperties { name value }\n                }\n                dtds {\n                    goid systemId checksum \n                    publicId description content\n                }\n                cassandraConnections {\n                    goid name checksum \n                    enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n                    properties { name value }\n                }\n                clusterProperties {\n                    goid name checksum \n                    description hiddenProperty value\n                }\n                emailListeners {\n                    goid name checksum \n                    enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n                    properties { name value }\n                }\n                fips {\n                    goid name checksum \n                    enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n                    certificateReferences { \n                        goid name subjectDn thumbprintSha1 checksum \n                        verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                        revocationCheckPolicy { goid name } \n                        notBefore notAfter certBase64 \n                    }\n                }\n                fipGroups {\n                    goid name providerName checksum \n                    description \n                    members { \n                        goid name login providerName checksum \n                        subjectDn certBase64 firstName lastName email \n                    }\n                }\n                fipUsers {\n                    goid name login providerName checksum \n                    subjectDn certBase64 firstName lastName email \n                    memberOf { \n                        goid name providerName checksum \n                        description \n                    }\n                }\n                internalGroups {\n                    goid name checksum \n                    description \n                    members { \n                        goid name login checksum \n                        enabled password certBase64 firstName lastName email \n                    }\n                }\n                internalUsers {\n                    goid name login checksum \n                    enabled password certBase64 firstName lastName email \n                    memberOf { goid name checksum description }\n                }\n                jdbcConnections {\n                    goid name checksum \n                    enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n                    properties { name value }\n                }\n                jmsDestinations {\n                    goid connectionGoid name direction providerType checksum \n                    enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n                    jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    destinationType destinationName destinationUsername destinationPassword \n                    destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    properties { name value }\n                }\n                keys {\n                    goid keystoreId alias checksum \n                    keyType subjectDn p12 certChain\n                }\n                ldaps {\n                    goid name checksum \n                    ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n                    userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n                    groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n                }\n                listenPorts {\n                    goid name checksum \n                    enabled protocol port hardwiredServiceName enabledFeatures \n                    tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n                    properties { name value }\n                }\n                schemas {\n                    goid systemId checksum \n                    targetNs description content\n                }\n                secrets {\n                    goid name checksum \n                    description secret secretType variableReferencable\n                }\n                serverModuleFiles {\n                    goid name checksum \n                    moduleType moduleSha256 signature signerCertBase64 \n                    properties { name value } \n                    moduleStates { nodeId nodeName state description } \n                    moduleStateSummary { state description }\n                }\n                smConfigs {\n                    goid name checksum \n                    enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n                    properties { name value }\n                }\n                trustedCerts {\n                    goid name subjectDn thumbprintSha1 checksum \n                    verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                    revocationCheckPolicy { goid name } \n                    notBefore notAfter certBase64\n                }\n            }\n        }\n    }\n}",
+								"query": "query policyFragmentByName ($name: String!) {\n    policyFragmentByName (name: $name) {\n        goid\n        guid\n        name\n        checksum\n\n        folderPath\n        soap\n        policy {\n            xml\n            allDependencies {\n                encassConfigs {\n                    goid guid name checksum \n                    description policyName \n                    encassArgs { name type ordinal guiPrompt guiLabel } \n                    encassResults{ name type } \n                    properties { name value }\n                }\n                policyFragments {\n                    goid guid name checksum \n                    folderPath soap \n                    policy { xml }\n                }\n\n                activeConnectors {\n                    goid name checksum \n                    enabled connectorType hardwiredServiceName \n                    properties { name value } \n                    advancedProperties { name value }\n                }\n                dtds {\n                    goid systemId checksum \n                    publicId description content\n                }\n                cassandraConnections {\n                    goid name checksum \n                    enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n                    properties { name value }\n                }\n                clusterProperties {\n                    goid name checksum \n                    description hiddenProperty value\n                }\n                emailListeners {\n                    goid name checksum \n                    enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n                    properties { name value }\n                }\n                fips {\n                    goid name checksum \n                    enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n                    certificateReferences { \n                        goid name subjectDn thumbprintSha1 checksum \n                        verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                        revocationCheckPolicy { goid name } \n                        notBefore notAfter certBase64 \n                    }\n                }\n                fipGroups {\n                    goid name providerName checksum \n                    description \n                    members { \n                        goid name login providerName checksum \n                        subjectDn certBase64 firstName lastName email \n                    }\n                }\n                fipUsers {\n                    goid name login providerName checksum \n                    subjectDn certBase64 firstName lastName email \n                    memberOf { \n                        goid name providerName checksum \n                        description \n                    }\n                }\n                internalGroups {\n                    goid name checksum \n                    description \n                    members { \n                        goid name login checksum \n                        enabled password certBase64 firstName lastName email \n                    }\n                }\n                internalUsers {\n                    goid name login checksum \n                    enabled password certBase64 firstName lastName email \n                    memberOf { goid name checksum description }\n                }\n                jdbcConnections {\n                    goid name checksum \n                    enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n                    properties { name value }\n                }\n                jmsDestinations {\n                    goid connectionGoid name direction providerType checksum \n                    enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n                    jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    destinationType destinationName destinationUsername destinationPassword \n                    destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    properties { name value }\n                }\n                keys {\n                    goid keystoreId alias checksum \n                    keyType subjectDn p12 certChain\n                }\n                ldaps {\n                    goid name checksum \n                    ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n                    userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n                    groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n                }\n                listenPorts {\n                    goid name checksum \n                    enabled protocol port hardwiredServiceName enabledFeatures \n                    tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n                    properties { name value }\n                }\n                schemas {\n                    goid systemId checksum \n                    targetNs description content\n                }\n                secrets {\n                    goid name checksum \n                    description secret secretType variableReferencable\n                }\n                serverModuleFiles {\n                    goid name checksum \n                    moduleType moduleSha256 signature signerCertBase64 \n                    properties { name value } \n                    moduleStates { nodeId nodeName state description } \n                    moduleStateSummary { state description }\n                }\n                smConfigs {\n                    goid name checksum \n                    enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n                    properties { name value }\n                }\n                revocationCheckPolicies {\n                goid name checksum defaultPolicy defaultSuccess\n                continueOnServerUnavailable\n                    revocationCheckPolicyItems {\n                        ... on RevocationCheckPolicyItem {\n                        type url allowIssuerSignature\n                        nonceUsage signerThumbprintSha1s\n                        }\n                    }\n                }\n                trustedCerts {\n                    goid name subjectDn thumbprintSha1 checksum \n                    verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                    revocationCheckPolicy { goid name } \n                    notBefore notAfter certBase64\n                }\n            }\n        }\n    }\n}",
 								"variables": "{\n    \"name\": \"some-policy\"\n}"
 							}
 						},
@@ -141,7 +143,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query serviceWithDependencies ($resolutionPath: String!) {\n    webApiServiceByResolutionPath (resolutionPath: $resolutionPath) {\n        goid\n        guid\n        name\n        resolutionPath\n        checksum\n\n        enabled\n        folderPath\n        methodsAllowed\n        properties {name value}\n        tracingEnabled\n        wssProcessingEnabled\n        policy {\n            xml\n            allDependencies {\n                encassConfigs {\n                    goid guid name checksum \n                    description policyName \n                    encassArgs { name type ordinal guiPrompt guiLabel } \n                    encassResults{ name type } \n                    properties { name value }\n                }\n                policyFragments {\n                    goid guid name checksum \n                    folderPath soap \n                    policy { xml }\n                }\n\n                activeConnectors {\n                    goid name checksum \n                    enabled connectorType hardwiredServiceName \n                    properties { name value } \n                    advancedProperties { name value }\n                }\n                dtds {\n                    goid systemId checksum \n                    publicId description content\n                }\n                cassandraConnections {\n                    goid name checksum \n                    enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n                    properties { name value }\n                }\n                clusterProperties {\n                    goid name checksum \n                    description hiddenProperty value\n                }\n                emailListeners {\n                    goid name checksum \n                    enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n                    properties { name value }\n                }\n                fips {\n                    goid name checksum \n                    enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n                    certificateReferences { \n                        goid name subjectDn thumbprintSha1 checksum \n                        verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                        revocationCheckPolicy { goid name } \n                        notBefore notAfter certBase64 \n                    }\n                }\n                fipGroups {\n                    goid name providerName checksum \n                    description \n                    members { \n                        goid name login providerName checksum \n                        subjectDn certBase64 firstName lastName email \n                    }\n                }\n                fipUsers {\n                    goid name login providerName checksum \n                    subjectDn certBase64 firstName lastName email \n                    memberOf { \n                        goid name providerName checksum \n                        description \n                    }\n                }\n                internalGroups {\n                    goid name checksum \n                    description \n                    members { \n                        goid name login checksum \n                        enabled password certBase64 firstName lastName email \n                    }\n                }\n                internalUsers {\n                    goid name login checksum \n                    enabled password certBase64 firstName lastName email \n                    memberOf { goid name checksum description }\n                }\n                jdbcConnections {\n                    goid name checksum \n                    enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n                    properties { name value }\n                }\n                jmsDestinations {\n                    goid connectionGoid name direction providerType checksum \n                    enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n                    jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    destinationType destinationName destinationUsername destinationPassword \n                    destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    properties { name value }\n                }\n                keys {\n                    goid keystoreId alias checksum \n                    keyType subjectDn p12 certChain\n                }\n                ldaps {\n                    goid name checksum \n                    ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n                    userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n                    groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n                }\n                listenPorts {\n                    goid name checksum \n                    enabled protocol port hardwiredServiceName enabledFeatures \n                    tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n                    properties { name value }\n                }\n                schemas {\n                    goid systemId checksum \n                    targetNs description content\n                }\n                secrets {\n                    goid name checksum \n                    description secret secretType variableReferencable\n                }\n                serverModuleFiles {\n                    goid name checksum \n                    moduleType moduleSha256 signature signerCertBase64 \n                    properties { name value } \n                    moduleStates { nodeId nodeName state description } \n                    moduleStateSummary { state description }\n                }\n                smConfigs {\n                    goid name checksum \n                    enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n                    properties { name value }\n                }\n                trustedCerts {\n                    goid name subjectDn thumbprintSha1 checksum \n                    verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                    revocationCheckPolicy { goid name } \n                    notBefore notAfter certBase64\n                }\n            }\n        }\n    }\n}",
+								"query": "query serviceWithDependencies ($resolutionPath: String!) {\n    webApiServiceByResolutionPath (resolutionPath: $resolutionPath) {\n        goid\n        guid\n        name\n        resolutionPath\n        checksum\n\n        enabled\n        folderPath\n        methodsAllowed\n        properties {name value}\n        tracingEnabled\n        wssProcessingEnabled\n        policy {\n            xml\n            allDependencies {\n                encassConfigs {\n                    goid guid name checksum \n                    description policyName \n                    encassArgs { name type ordinal guiPrompt guiLabel } \n                    encassResults{ name type } \n                    properties { name value }\n                }\n                policyFragments {\n                    goid guid name checksum \n                    folderPath soap \n                    policy { xml }\n                }\n\n                activeConnectors {\n                    goid name checksum \n                    enabled connectorType hardwiredServiceName \n                    properties { name value } \n                    advancedProperties { name value }\n                }\n                dtds {\n                    goid systemId checksum \n                    publicId description content\n                }\n                cassandraConnections {\n                    goid name checksum \n                    enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n                    properties { name value }\n                }\n                clusterProperties {\n                    goid name checksum \n                    description hiddenProperty value\n                }\n                emailListeners {\n                    goid name checksum \n                    enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n                    properties { name value }\n                }\n                fips {\n                    goid name checksum \n                    enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n                    certificateReferences { \n                        goid name subjectDn thumbprintSha1 checksum \n                        verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                        revocationCheckPolicy { goid name } \n                        notBefore notAfter certBase64 \n                    }\n                }\n                fipGroups {\n                    goid name providerName checksum \n                    description \n                    members { \n                        goid name login providerName checksum \n                        subjectDn certBase64 firstName lastName email \n                    }\n                }\n                fipUsers {\n                    goid name login providerName checksum \n                    subjectDn certBase64 firstName lastName email \n                    memberOf { \n                        goid name providerName checksum \n                        description \n                    }\n                }\n                internalGroups {\n                    goid name checksum \n                    description \n                    members { \n                        goid name login checksum \n                        enabled password certBase64 firstName lastName email \n                    }\n                }\n                internalUsers {\n                    goid name login checksum \n                    enabled password certBase64 firstName lastName email \n                    memberOf { goid name checksum description }\n                }\n                jdbcConnections {\n                    goid name checksum \n                    enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n                    properties { name value }\n                }\n                jmsDestinations {\n                    goid connectionGoid name direction providerType checksum \n                    enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n                    jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    destinationType destinationName destinationUsername destinationPassword \n                    destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n                    properties { name value }\n                }\n                keys {\n                    goid keystoreId alias checksum \n                    keyType subjectDn p12 certChain\n                }\n                ldaps {\n                    goid name checksum \n                    ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n                    userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n                    groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n                }\n                listenPorts {\n                    goid name checksum \n                    enabled protocol port hardwiredServiceName enabledFeatures \n                    tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n                    properties { name value }\n                }\n                schemas {\n                    goid systemId checksum \n                    targetNs description content\n                }\n                secrets {\n                    goid name checksum \n                    description secret secretType variableReferencable\n                }\n                serverModuleFiles {\n                    goid name checksum \n                    moduleType moduleSha256 signature signerCertBase64 \n                    properties { name value } \n                    moduleStates { nodeId nodeName state description } \n                    moduleStateSummary { state description }\n                }\n                smConfigs {\n                    goid name checksum \n                    enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n                    properties { name value }\n                }\n                revocationCheckPolicies {\n                goid name checksum defaultPolicy defaultSuccess\n                continueOnServerUnavailable\n                    revocationCheckPolicyItems {\n                        ... on RevocationCheckPolicyItem {\n                        type url allowIssuerSignature\n                        nonceUsage signerThumbprintSha1s\n                        }\n                    }\n                }\n                trustedCerts {\n                    goid name subjectDn thumbprintSha1 checksum \n                    verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n                    revocationCheckPolicy { goid name } \n                    notBefore notAfter certBase64\n                }\n            }\n        }\n    }\n}",
 								"variables": "{\n    \"resolutionPath\" : \"/some-webapi\"\n}"
 							}
 						},
@@ -219,7 +221,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query everything {\n    webApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value }\n        policy { xml }\n    }\n    soapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value }\n        wsdl \n        policy { xml }\n    }\n    internalWebApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value } \n        policy { xml }\n    }\n    internalSoapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value } \n        wsdl \n        policy { xml }\n    }\n    encassConfigs {\n        goid guid name checksum \n        description policyName \n        encassArgs { name type ordinal guiPrompt guiLabel } \n        encassResults{ name type } \n        properties { name value }\n    }\n    globalPolicies {\n        goid guid name tag checksum \n        folderPath \n        policy { xml }\n    }\n    backgroundTaskPolicies {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n    policyFragments {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n\n    activeConnectors {\n        goid name checksum \n        enabled connectorType hardwiredServiceName \n        properties { name value } \n        advancedProperties { name value }\n    }\n    dtds {\n        goid systemId checksum \n        publicId description content\n    }\n    cassandraConnections {\n        goid name checksum \n        enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n        properties { name value }\n    }\n    clusterProperties {\n        goid name checksum \n        description hiddenProperty value\n    }\n    emailListeners {\n        goid name checksum \n        enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n        properties { name value }\n    }\n    fips {\n        goid name checksum \n        enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n        certificateReferences { \n             goid name subjectDn thumbprintSha1 checksum \n             verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n             revocationCheckPolicy { goid name } \n             notBefore notAfter certBase64 \n        }\n    }\n    fipGroups {\n        goid name providerName checksum \n        description \n        members { \n            goid name login providerName checksum \n            subjectDn certBase64 firstName lastName email \n        }\n    }\n    fipUsers {\n        goid name login providerName checksum \n        subjectDn certBase64 firstName lastName email \n        memberOf { \n            goid name providerName checksum \n            description \n        }\n    }\n    internalDtds {\n        goid systemId checksum \n        publicId description content\n    }\n    internalGroups {\n        goid name checksum \n        description \n        members { \n            goid name login checksum \n            enabled password certBase64 firstName lastName email \n        }\n    }\n    internalSchemas {\n        goid systemId checksum \n        targetNs description content\n    }\n    internalUsers {\n         goid name login checksum \n         enabled password certBase64 firstName lastName email \n         memberOf { goid name checksum description }\n    }\n    jdbcConnections {\n         goid name checksum \n         enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n         properties { name value }\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum \n         enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n         jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         destinationType destinationName destinationUsername destinationPassword \n         destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         properties { name value }\n    }\n    keys {\n         goid keystoreId alias checksum \n         keyType subjectDn p12 certChain\n    }\n    ldaps {\n        goid name checksum \n        ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n        userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n        groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n    }\n    listenPorts {\n         goid name checksum \n         enabled protocol port hardwiredServiceName enabledFeatures \n         tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n         properties { name value }\n    }\n    scheduledTasks {\n         goid name checksum \n         policyName jobType cronExpression executeOnSingleNode executeOnCreation executionDate status runAsUser runAsUserProviderName\n    }\n    schemas {\n         goid systemId checksum \n         targetNs description content\n    }\n    secrets {\n         goid name checksum \n         description secret secretType variableReferencable\n    }\n    serverModuleFiles {\n        goid name checksum \n        moduleType moduleSha256 signature signerCertBase64 \n        properties { name value } \n        moduleStates { nodeId nodeName state description } \n        moduleStateSummary { state description }\n    }\n    smConfigs {\n        goid name checksum \n        enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n        properties { name value }\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum \n         verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n         revocationCheckPolicy { goid name } \n         notBefore notAfter certBase64\n    }\n}",
+								"query": "query everything {\n    webApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value }\n        policy { xml }\n    }\n    soapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value }\n        wsdl \n        policy { xml }\n    }\n    internalWebApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value } \n        policy { xml }\n    }\n    internalSoapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value } \n        wsdl \n        policy { xml }\n    }\n    encassConfigs {\n        goid guid name checksum \n        description policyName \n        encassArgs { name type ordinal guiPrompt guiLabel } \n        encassResults{ name type } \n        properties { name value }\n    }\n    globalPolicies {\n        goid guid name tag checksum \n        folderPath \n        policy { xml }\n    }\n    backgroundTaskPolicies {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n    policyFragments {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n\n    activeConnectors {\n        goid name checksum \n        enabled connectorType hardwiredServiceName \n        properties { name value } \n        advancedProperties { name value }\n    }\n    dtds {\n        goid systemId checksum \n        publicId description content\n    }\n    cassandraConnections {\n        goid name checksum \n        enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n        properties { name value }\n    }\n    clusterProperties {\n        goid name checksum \n        description hiddenProperty value\n    }\n    emailListeners {\n        goid name checksum \n        enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n        properties { name value }\n    }\n    fips {\n        goid name checksum \n        enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n        certificateReferences { \n             goid name subjectDn thumbprintSha1 checksum \n             verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n             revocationCheckPolicy { goid name } \n             notBefore notAfter certBase64 \n        }\n    }\n    fipGroups {\n        goid name providerName checksum \n        description \n        members { \n            goid name login providerName checksum \n            subjectDn certBase64 firstName lastName email \n        }\n    }\n    fipUsers {\n        goid name login providerName checksum \n        subjectDn certBase64 firstName lastName email \n        memberOf { \n            goid name providerName checksum \n            description \n        }\n    }\n    internalDtds {\n        goid systemId checksum \n        publicId description content\n    }\n    internalGroups {\n        goid name checksum \n        description \n        members { \n            goid name login checksum \n            enabled password certBase64 firstName lastName email \n        }\n    }\n    internalSchemas {\n        goid systemId checksum \n        targetNs description content\n    }\n    internalUsers {\n         goid name login checksum \n         enabled password certBase64 firstName lastName email \n         memberOf { goid name checksum description }\n    }\n    jdbcConnections {\n         goid name checksum \n         enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n         properties { name value }\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum \n         enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n         jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         destinationType destinationName destinationUsername destinationPassword \n         destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         properties { name value }\n    }\n    keys {\n         goid keystoreId alias checksum \n         keyType subjectDn p12 certChain\n    }\n    ldaps {\n        goid name checksum \n        ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n        userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n        groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n    }\n    listenPorts {\n         goid name checksum \n         enabled protocol port hardwiredServiceName enabledFeatures \n         tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n         properties { name value }\n    }\n    scheduledTasks {\n         goid name checksum \n         policyName jobType cronExpression executeOnSingleNode executeOnCreation executionDate status runAsUser runAsUserProviderName\n    }\n    schemas {\n         goid systemId checksum \n         targetNs description content\n    }\n    secrets {\n         goid name checksum \n         description secret secretType variableReferencable\n    }\n    serverModuleFiles {\n        goid name checksum \n        moduleType moduleSha256 signature signerCertBase64 \n        properties { name value } \n        moduleStates { nodeId nodeName state description } \n        moduleStateSummary { state description }\n    }\n    smConfigs {\n        goid name checksum \n        enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n        properties { name value }\n    }\n    revocationCheckPolicies {\n        goid name checksum\n        defaultPolicy defaultSuccess continueOnServerUnavailable\n        revocationCheckPolicyItems  {\n            ... on RevocationCheckPolicyItem {\n                type url allowIssuerSignature nonceUsage signerThumbprintSha1s\n            }\n        }    \n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum \n         verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n         revocationCheckPolicy { goid name } \n         notBefore notAfter certBase64\n    }\n    clusterInfo {\n        name\n        nodes { name nodeId address uptime }\n    }\n    passwordPolicies {\n        goid checksum \n        forcePasswordChangeNewUser noRepeatingCharacters\n        minPasswordLength maxPasswordLength \n        upperMinimum  lowerMinimum numberMinimum symbolMinimum\n        nonNumericMinimum charDiffMinimum repeatFrequency\n        passwordExpiry allowableChangesPerDay        \n    }\n    administrativeUserAccountProperties {\n        goid name value checksum\n    }\n    serviceResolutionConfigs {\n        goid checksum\n        resolutionPathRequired resolutionPathCaseSensitive\n        useL7OriginalUrl useServiceGoid\n        useSoapAction useSoapBodyChildNamespace        \n    }\n}",
 								"variables": "{}"
 							}
 						},
@@ -253,7 +255,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query summary {\n    webApiServices {\n         goid name resolutionPath checksum\n    }\n    soapServices {\n         goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum\n    }\n    internalWebApiServices {\n         goid name resolutionPath checksum\n    }\n    internalSoapServices {\n         goid resolutionPath checksum\n    }\n    encassConfigs {\n         goid guid name checksum\n    }\n    globalPolicies {\n         goid guid name tag checksum\n    }\n    backgroundTaskPolicies {\n         goid guid name checksum\n    }\n    policyFragments {\n         goid guid name checksum\n    }\n\n    activeConnectors {\n         goid name checksum\n    }\n    cassandraConnections {\n         goid name checksum\n    }\n    clusterProperties {\n         goid name checksum\n    }\n    dtds {\n         goid systemId checksum\n    }\n    emailListeners {\n         goid name checksum\n    }\n    fips {\n         goid name checksum\n    }\n    fipGroups {\n         goid name providerName checksum\n    }\n    fipUsers {\n         goid name providerName checksum\n    }\n    internalDtds {\n         goid systemId checksum\n    }\n    internalGroups {\n         goid name checksum\n    }\n    internalSchemas {\n         goid systemId checksum\n    }\n    internalUsers {\n         goid name login checksum\n    }\n    jdbcConnections {\n         goid name checksum\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum\n    }\n    keys {\n         goid keystoreId alias checksum\n    }\n    ldaps {\n         goid name checksum\n    }\n    listenPorts {\n         goid name checksum\n    }\n    scheduledTasks {\n         goid name checksum\n    }\n    schemas {\n         goid systemId checksum\n    }\n    secrets {\n         goid name checksum\n    }\n    serverModuleFiles {\n         goid name checksum\n    }\n    smConfigs {\n         goid name checksum\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum\n    }\n}",
+								"query": "query summary {\n    webApiServices {\n         goid name resolutionPath checksum\n    }\n    soapServices {\n         goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum\n    }\n    internalWebApiServices {\n         goid name resolutionPath checksum\n    }\n    internalSoapServices {\n         goid resolutionPath checksum\n    }\n    encassConfigs {\n         goid guid name checksum\n    }\n    globalPolicies {\n         goid guid name tag checksum\n    }\n    backgroundTaskPolicies {\n         goid guid name checksum\n    }\n    policyFragments {\n         goid guid name checksum\n    }\n\n    activeConnectors {\n         goid name checksum\n    }\n    cassandraConnections {\n         goid name checksum\n    }\n    clusterProperties {\n         goid name checksum\n    }\n    dtds {\n         goid systemId checksum\n    }\n    emailListeners {\n         goid name checksum\n    }\n    fips {\n         goid name checksum\n    }\n    fipGroups {\n         goid name providerName checksum\n    }\n    fipUsers {\n         goid name providerName checksum\n    }\n    internalDtds {\n         goid systemId checksum\n    }\n    internalGroups {\n         goid name checksum\n    }\n    internalSchemas {\n         goid systemId checksum\n    }\n    internalUsers {\n         goid name login checksum\n    }\n    jdbcConnections {\n         goid name checksum\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum\n    }\n    keys {\n         goid keystoreId alias checksum\n    }\n    ldaps {\n         goid name checksum\n    }\n    listenPorts {\n         goid name checksum\n    }\n    scheduledTasks {\n         goid name checksum\n    }\n    schemas {\n         goid systemId checksum\n    }\n    secrets {\n         goid name checksum\n    }\n    serverModuleFiles {\n         goid name checksum\n    }\n    smConfigs {\n         goid name checksum\n    }\n    revocationCheckPolicies {\n        goid name checksum\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum\n    }\n    passwordPolicies {\n        goid checksum    \n    }\n    administrativeUserAccountProperties {\n        goid name checksum\n    }\n    serviceResolutionConfigs {\n        goid checksum\n    }\n    clusterInfo {\n        name\n    }\n}",
 								"variables": "{}"
 							}
 						},
@@ -287,7 +289,7 @@
 						"body": {
 							"mode": "graphql",
 							"graphql": {
-								"query": "query summary {\n    webApiServices {\n         goid name resolutionPath checksum\n    }\n    soapServices {\n         goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum\n    }\n    internalWebApiServices {\n         goid name resolutionPath checksum\n    }\n    internalSoapServices {\n         goid resolutionPath checksum\n    }\n    encassConfigs {\n         goid guid name checksum\n    }\n    globalPolicies {\n         goid guid name tag checksum\n    }\n    backgroundTaskPolicies {\n         goid guid name checksum\n    }\n    policyFragments {\n         goid guid name checksum\n    }\n\n    activeConnectors {\n         goid name checksum\n    }\n    cassandraConnections {\n         goid name checksum\n    }\n    clusterProperties {\n         goid name checksum\n    }\n    dtds {\n         goid systemId checksum\n    }\n    emailListeners {\n         goid name checksum\n    }\n    fips {\n         goid name checksum\n    }\n    fipGroups {\n         goid name providerName checksum\n    }\n    fipUsers {\n         goid name providerName checksum\n    }\n    internalDtds {\n         goid systemId checksum\n    }\n    internalGroups {\n         goid name checksum\n    }\n    internalSchemas {\n         goid systemId checksum\n    }\n    internalUsers {\n         goid name login checksum\n    }\n    jdbcConnections {\n         goid name checksum\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum\n    }\n    keys {\n         goid keystoreId alias checksum\n    }\n    ldaps {\n         goid name checksum\n    }\n    listenPorts {\n         goid name checksum\n    }\n    scheduledTasks {\n         goid name checksum\n    }\n    schemas {\n         goid systemId checksum\n    }\n    secrets {\n         goid name checksum\n    }\n    serverModuleFiles {\n         goid name checksum\n    }\n    smConfigs {\n         goid name checksum\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum\n    }\n}",
+								"query": "query summary {\n    webApiServices {\n         goid name resolutionPath checksum\n    }\n    soapServices {\n         goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum\n    }\n    internalWebApiServices {\n         goid name resolutionPath checksum\n    }\n    internalSoapServices {\n         goid resolutionPath checksum\n    }\n    encassConfigs {\n         goid guid name checksum\n    }\n    globalPolicies {\n         goid guid name tag checksum\n    }\n    backgroundTaskPolicies {\n         goid guid name checksum\n    }\n    policyFragments {\n         goid guid name checksum\n    }\n\n    activeConnectors {\n         goid name checksum\n    }\n    cassandraConnections {\n         goid name checksum\n    }\n    clusterProperties {\n         goid name checksum\n    }\n    dtds {\n         goid systemId checksum\n    }\n    emailListeners {\n         goid name checksum\n    }\n    fips {\n         goid name checksum\n    }\n    fipGroups {\n         goid name providerName checksum\n    }\n    fipUsers {\n         goid name providerName checksum\n    }\n    internalDtds {\n         goid systemId checksum\n    }\n    internalGroups {\n         goid name checksum\n    }\n    internalSchemas {\n         goid systemId checksum\n    }\n    internalUsers {\n         goid name login checksum\n    }\n    jdbcConnections {\n         goid name checksum\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum\n    }\n    keys {\n         goid keystoreId alias checksum\n    }\n    ldaps {\n         goid name checksum\n    }\n    listenPorts {\n         goid name checksum\n    }\n    scheduledTasks {\n         goid name checksum\n    }\n    schemas {\n         goid systemId checksum\n    }\n    secrets {\n         goid name checksum\n    }\n    serverModuleFiles {\n         goid name checksum\n    }\n    smConfigs {\n         goid name checksum\n    }\n    revocationCheckPolicies {\n        goid name checksum\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum\n    }\n    passwordPolicies {\n        goid checksum    \n    }\n    administrativeUserAccountProperties {\n        goid name checksum\n    }\n    serviceResolutionConfigs {\n        goid checksum\n    }\n    clusterInfo {\n        name\n    }\n}",
 								"variables": "{}"
 							}
 						},
@@ -335,7 +337,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "query everything {\n    webApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value }\n        policy { xml }\n    }\n    soapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value }\n        wsdl \n        policy { xml }\n    }\n    internalWebApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value } \n        policy { xml }\n    }\n    internalSoapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value } \n        wsdl \n        policy { xml }\n    }\n    encassConfigs {\n        goid guid name checksum \n        description policyName \n        encassArgs { name type ordinal guiPrompt guiLabel } \n        encassResults{ name type } \n        properties { name value }\n    }\n    globalPolicies {\n        goid guid name tag checksum \n        folderPath \n        policy { xml }\n    }\n    backgroundTaskPolicies {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n    policyFragments {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n\n    activeConnectors {\n        goid name checksum \n        enabled connectorType hardwiredServiceName \n        properties { name value } \n        advancedProperties { name value }\n    }\n    cassandraConnections {\n        goid name checksum \n        enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n        properties { name value }\n    }\n    clusterProperties {\n        goid name checksum \n        description hiddenProperty value\n    }\n    dtds {\n        goid systemId checksum \n        publicId description content\n    }\n    emailListeners {\n        goid name checksum \n        enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n        properties { name value }\n    }\n    fips {\n        goid name checksum \n        enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n        certificateReferences { \n             goid name subjectDn thumbprintSha1 checksum \n             verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n             revocationCheckPolicy { goid name } \n             notBefore notAfter certBase64 \n        }\n    }\n    fipGroups {\n        goid name providerName checksum \n        description \n        members { \n            goid name login providerName checksum \n            subjectDn certBase64 firstName lastName email \n        }\n    }\n    fipUsers {\n        goid name login providerName checksum \n        subjectDn certBase64 firstName lastName email \n        memberOf { \n            goid name providerName checksum \n            description \n        }\n    }\n    internalDtds {\n        goid systemId checksum \n        publicId description content\n    }\n    internalGroups {\n        goid name checksum \n        description \n        members { \n            goid name login checksum \n            enabled password certBase64 firstName lastName email \n        }\n    }\n    internalSchemas {\n        goid systemId checksum \n        targetNs description content\n    }\n    internalUsers {\n         goid name login checksum \n         enabled password certBase64 firstName lastName email \n         memberOf { goid name checksum description }\n    }\n    jdbcConnections {\n         goid name checksum \n         enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n         properties { name value }\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum \n         enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n         jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         destinationType destinationName destinationUsername destinationPassword \n         destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         properties { name value }\n    }\n    keys {\n         goid keystoreId alias checksum \n         keyType subjectDn p12 certChain\n    }\n    ldaps {\n        goid name checksum \n        ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n        userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n        groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n    }\n    listenPorts {\n         goid name checksum \n         enabled protocol port hardwiredServiceName enabledFeatures \n         tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n         properties { name value }\n    }\n    scheduledTasks {\n         goid name checksum \n         policyName jobType cronExpression executeOnSingleNode executeOnCreation executionDate status runAsUser runAsUserProviderName\n    }\n    schemas {\n         goid systemId checksum \n         targetNs description content\n    }\n    secrets {\n         goid name checksum \n         description secret secretType variableReferencable\n    }\n    serverModuleFiles {\n        goid name checksum \n        moduleType moduleSha256 signature signerCertBase64 \n        properties { name value } \n        moduleStates { nodeId nodeName state description } \n        moduleStateSummary { state description }\n    }\n    smConfigs {\n        goid name checksum \n        enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n        properties { name value }\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum \n         verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n         revocationCheckPolicy { goid name } \n         notBefore notAfter certBase64\n    }\n}",
+										"query": "query everything {\n    webApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value }\n        policy { xml }\n    }\n    soapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value }\n        wsdl \n        policy { xml }\n    }\n    internalWebApiServices {\n        goid name resolutionPath checksum \n        enabled folderPath methodsAllowed tracingEnabled wssProcessingEnabled \n        properties { name value } \n        policy { xml }\n    }\n    internalSoapServices {\n        goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum \n        enabled folderPath soapVersion methodsAllowed tracingEnabled wssProcessingEnabled laxResolution \n        properties { name value } \n        wsdl \n        policy { xml }\n    }\n    encassConfigs {\n        goid guid name checksum \n        description policyName \n        encassArgs { name type ordinal guiPrompt guiLabel } \n        encassResults{ name type } \n        properties { name value }\n    }\n    globalPolicies {\n        goid guid name tag checksum \n        folderPath \n        policy { xml }\n    }\n    backgroundTaskPolicies {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n    policyFragments {\n        goid guid name checksum \n        folderPath soap \n        policy { xml }\n    }\n\n    activeConnectors {\n        goid name checksum \n        enabled connectorType hardwiredServiceName \n        properties { name value } \n        advancedProperties { name value }\n    }\n    cassandraConnections {\n        goid name checksum \n        enabled keyspace contactPoints port compression username securePasswordName sslEnabled cipherSuites \n        properties { name value }\n    }\n    clusterProperties {\n        goid name checksum \n        description hiddenProperty value\n    }\n    dtds {\n        goid systemId checksum \n        publicId description content\n    }\n    emailListeners {\n        goid name checksum \n        enabled serverType hostname port folder deleteOnReceive username password hardwiredServiceName sslEnabled pollInterval sizeLimit \n        properties { name value }\n    }\n    fips {\n        goid name checksum \n        enableCredentialTypeSaml enableCredentialTypeX509 certificateValidation \n        certificateReferences { \n             goid name subjectDn thumbprintSha1 checksum \n             verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n             revocationCheckPolicy { goid name } \n             notBefore notAfter certBase64 \n        }\n    }\n    fipGroups {\n        goid name providerName checksum \n        description \n        members { \n            goid name login providerName checksum \n            subjectDn certBase64 firstName lastName email \n        }\n    }\n    fipUsers {\n        goid name login providerName checksum \n        subjectDn certBase64 firstName lastName email \n        memberOf { \n            goid name providerName checksum \n            description \n        }\n    }\n    internalDtds {\n        goid systemId checksum \n        publicId description content\n    }\n    internalGroups {\n        goid name checksum \n        description \n        members { \n            goid name login checksum \n            enabled password certBase64 firstName lastName email \n        }\n    }\n    internalSchemas {\n        goid systemId checksum \n        targetNs description content\n    }\n    internalUsers {\n         goid name login checksum \n         enabled password certBase64 firstName lastName email \n         memberOf { goid name checksum description }\n    }\n    jdbcConnections {\n         goid name checksum \n         enabled driverClass jdbcUrl username password minPoolSize maxPoolSize \n         properties { name value }\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum \n         enabled template initialContextFactoryClassname connectionFactoryName jndiUrl jndiUsername jndiPassword \n         jndiSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         destinationType destinationName destinationUsername destinationPassword \n         destinationSslDetails { sslEnabled sslForAuthenticationOnly sslVerifyServerCertificate sslVerifyServerHostname sslClientKeyAlias } \n         properties { name value }\n    }\n    keys {\n         goid keystoreId alias checksum \n         keyType subjectDn p12 certChain\n    }\n    ldaps {\n        goid name checksum \n        ldapUrls ldapsClientAuthEnabled ldapsClientKeystoreId ldapsClientKeyAlias searchBase writable bindDn bindPassword \n        userMappings { objClass nameAttrName loginAttrName passwdAttrName firstNameAttrName lastNameAttrName emailNameAttrName kerberosAttrName kerberosEnterpriseAttrName userCertAttrName passwdType { val } } \n        groupMappings { objClass nameAttrName memberAttrName memberStrategy { val } }\n    }\n    listenPorts {\n         goid name checksum \n         enabled protocol port hardwiredServiceName enabledFeatures \n         tlsSettings { clientAuthentication keystoreId keyAlias tlsVersions cipherSuites useCipherSuitesOrder } \n         properties { name value }\n    }\n    scheduledTasks {\n         goid name checksum \n         policyName jobType cronExpression executeOnSingleNode executeOnCreation executionDate status runAsUser runAsUserProviderName\n    }\n    schemas {\n         goid systemId checksum \n         targetNs description content\n    }\n    secrets {\n         goid name checksum \n         description secret secretType variableReferencable\n    }\n    serverModuleFiles {\n        goid name checksum \n        moduleType moduleSha256 signature signerCertBase64 \n        properties { name value } \n        moduleStates { nodeId nodeName state description } \n        moduleStateSummary { state description }\n    }\n    smConfigs {\n        goid name checksum \n        enabled agentHost agentIP agentHostConfig agentSecret cryptoMode ipCheckEnabled updateSSOToken clusterFailoverThreshold nonClusterFailover username securePasswordName \n        properties { name value }\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum \n         verifyHostname trustAnchor trustedFor revocationCheckPolicyType \n         revocationCheckPolicy { goid name } \n         notBefore notAfter certBase64\n    }\n    revocationCheckPolicies {\n        goid\n        name\n        defaultPolicy\n        defaultSuccess\n        continueOnServerUnavailable\n        checksum         \n        revocationCheckPolicyItems  {\n            ... on RevocationCheckPolicyItem {                \n                type\n                url\n                allowIssuerSignature\n                nonceUsage\n                signerThumbprintSha1s\n            }\n        }    \n    }\n    clusterInfo {\n        name\n        nodes\n        {\n            name\n            nodeId\n            address\n            uptime\n        }\n    }\n    passwordPolicies {\n        goid\n        forcePasswordChangeNewUser\n        noRepeatingCharacters\n        minPasswordLength\n        maxPasswordLength\n        upperMinimum\n        lowerMinimum\n        numberMinimum\n        symbolMinimum\n        nonNumericMinimum\n        charDiffMinimum\n        repeatFrequency\n        passwordExpiry\n        allowableChangesPerDay\n        checksum\n    }\n    administrativeUserAccountProperties {\n        goid\n        name\n        value\n        checksum\n    }\n    serviceResolutionConfigs {\n        goid\n        resolutionPathRequired\n        resolutionPathCaseSensitive\n        useL7OriginalUrl\n        useServiceGoid\n        useSoapAction\n        useSoapBodyChildNamespace\n        checksum\n    }    \n}",
 										"variables": "{}"
 									}
 								},
@@ -370,7 +372,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "query summary {\n    webApiServices {\n         goid name resolutionPath checksum\n    }\n    soapServices {\n         goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum\n    }\n    internalWebApiServices {\n         goid name resolutionPath checksum\n    }\n    internalSoapServices {\n         goid resolutionPath checksum\n    }\n    encassConfigs {\n         goid guid name checksum\n    }\n    globalPolicies {\n         goid guid name tag checksum\n    }\n    backgroundTaskPolicies {\n         goid guid name checksum\n    }\n    policyFragments {\n         goid guid name checksum\n    }\n\n    activeConnectors {\n         goid name checksum\n    }\n    cassandraConnections {\n         goid name checksum\n    }\n    clusterProperties {\n         goid name checksum\n    }\n    dtds {\n         goid systemId checksum\n    }\n    emailListeners {\n         goid name checksum\n    }\n    fips {\n         goid name checksum\n    }\n    fipGroups {\n         goid name providerName checksum\n    }\n    fipUsers {\n         goid name providerName checksum\n    }\n    internalDtds {\n         goid systemId checksum\n    }\n    internalGroups {\n         goid name checksum\n    }\n    internalSchemas {\n         goid systemId checksum\n    }\n    internalUsers {\n         goid name login checksum\n    }\n    jdbcConnections {\n         goid name checksum\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum\n    }\n    keys {\n         goid keystoreId alias checksum\n    }\n    ldaps {\n         goid name checksum\n    }\n    listenPorts {\n         goid name checksum\n    }\n    scheduledTasks {\n         goid name checksum\n    }\n    schemas {\n         goid systemId checksum\n    }\n    secrets {\n         goid name checksum\n    }\n    serverModuleFiles {\n         goid name checksum\n    }\n    smConfigs {\n         goid name checksum\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum\n    }\n}",
+										"query": "query summary {\n    webApiServices {\n         goid name resolutionPath checksum\n    }\n    soapServices {\n         goid name resolutionPath resolvers { soapActions baseUri resolutionPath } checksum\n    }\n    internalWebApiServices {\n         goid name resolutionPath checksum\n    }\n    internalSoapServices {\n         goid resolutionPath checksum\n    }\n    encassConfigs {\n         goid guid name checksum\n    }\n    globalPolicies {\n         goid guid name tag checksum\n    }\n    backgroundTaskPolicies {\n         goid guid name checksum\n    }\n    policyFragments {\n         goid guid name checksum\n    }\n\n    activeConnectors {\n         goid name checksum\n    }\n    cassandraConnections {\n         goid name checksum\n    }\n    clusterProperties {\n         goid name checksum\n    }\n    dtds {\n         goid systemId checksum\n    }\n    emailListeners {\n         goid name checksum\n    }\n    fips {\n         goid name checksum\n    }\n    fipGroups {\n         goid name providerName checksum\n    }\n    fipUsers {\n         goid name providerName checksum\n    }\n    internalDtds {\n         goid systemId checksum\n    }\n    internalGroups {\n         goid name checksum\n    }\n    internalSchemas {\n         goid systemId checksum\n    }\n    internalUsers {\n         goid name login checksum\n    }\n    jdbcConnections {\n         goid name checksum\n    }\n    jmsDestinations {\n         goid connectionGoid name direction providerType checksum\n    }\n    keys {\n         goid keystoreId alias checksum\n    }\n    ldaps {\n         goid name checksum\n    }\n    listenPorts {\n         goid name checksum\n    }\n    scheduledTasks {\n         goid name checksum\n    }\n    schemas {\n         goid systemId checksum\n    }\n    secrets {\n         goid name checksum\n    }\n    serverModuleFiles {\n         goid name checksum\n    }\n    smConfigs {\n         goid name checksum\n    }\n    trustedCerts {\n         goid name subjectDn thumbprintSha1 checksum\n    }\n    revocationCheckPolicies {\n        goid name checksum\n    }\n    passwordPolicies {\n        goid checksum    \n    }\n    administrativeUserAccountProperties {\n        goid name checksum\n    }\n    serviceResolutionConfigs {\n        goid checksum\n    }\n    clusterInfo {\n        name\n    }\n}",
 										"variables": "{}"
 									}
 								},
@@ -482,6 +484,66 @@
 											]
 										},
 										"description": "# Cluster Property by Name\n\nGet the cluster property with the given name\n\nInput: name"
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Administrative User Account Properties",
+					"item": [
+						{
+							"name": "Mutation",
+							"item": [
+								{
+									"name": "Set Administrative User Account Properties",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "mutation setAdministrativeUserAccountProperties ($input: [AdministrativeUserAccountPropertyInput!]!) {\n    setAdministrativeUserAccountProperties (input: $input) {\n        detailedStatus {\n            status\n            description\n        }\n        administrativeUserAccountProperties {\n            goid\n            checksum\n            name\n            value\n        }\n    }\n}",
+												"variables": "{\r\n  \"input\": [{\r\n    \"name\": \"logonMaxAllowableAttempts\",\r\n    \"value\": \"17\"\r\n  },\r\n  {\r\n    \"name\": \"logonLockoutTime\",\r\n    \"value\": \"1300\"\r\n  },{\r\n    \"name\": \"logonInactivityPeriod\",\r\n    \"value\": \"20\"\r\n  },\r\n  {\r\n    \"name\": \"logonSessionExpiry\",\r\n    \"value\": \"25\"\r\n  }]\r\n}"
+											}
+										},
+										"url": {
+											"raw": "{{target_gw}}",
+											"host": [
+												"{{target_gw}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Query",
+							"item": [
+								{
+									"name": "Get Administrative User Account Properties",
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query administrativeUserAccountProperties {\n        administrativeUserAccountProperties {\n            goid\n            checksum\n            name\n            value\n        }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										}
 									},
 									"response": []
 								}
@@ -669,6 +731,52 @@
 						}
 					],
 					"description": "# Cassandra Connections"
+				},
+				{
+					"name": "Cluster Info",
+					"item": [
+						{
+							"name": "Query",
+							"item": [
+								{
+									"name": "Get Cluster Info",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query clusterInfo {\n    clusterInfo {\n        name\n        nodes\n        {\n            name\n            nodeId\n            address\n            uptime\n        }\n    }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										},
+										"description": "# Retrieves the gateway cluster information"
+									},
+									"response": []
+								}
+							]
+						}
+					]
 				},
 				{
 					"name": "Cluster Properties",
@@ -2304,6 +2412,74 @@
 					"name": "Listen Ports",
 					"item": [
 						{
+							"name": "Query",
+							"item": [
+								{
+									"name": "All Listen Ports",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query listenPorts {\n    listenPorts {\n        goid \n        name \n        checksum \n        \n        enabled \n        protocol \n        port \n        hardwiredServiceName \n        enabledFeatures \n        tlsSettings { \n            clientAuthentication \n            keystoreId \n            keyAlias \n            tlsVersions \n            cipherSuites \n            useCipherSuitesOrder \n        } \n        properties { name value }\n\n        hardwiredService {\n            ... on PublishedService {\n                name \n                resolutionPath \n                folderPath \n                methodsAllowed \n                enabled\n            }\n        }\n    }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Listen Ports by Name",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query listenPortByName ($name : String!) {\n    listenPortByName (name : $name) {\n        goid \n        name \n        checksum \n        \n        enabled \n        protocol \n        port \n        hardwiredServiceName \n        enabledFeatures \n        tlsSettings { \n            clientAuthentication \n            keystoreId \n            keyAlias \n            tlsVersions \n            cipherSuites \n            useCipherSuitesOrder \n        } \n        properties { name value }\n\n        hardwiredService {\n            ... on PublishedService {\n                name \n                resolutionPath \n                folderPath \n                methodsAllowed \n                enabled\n            }\n        }\n    }\n}",
+												"variables": "{\n    \"name\" : \"some-listen-port\"\n}"
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Listen Ports by Protocol",
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query listenPortsByProtocol ($protocol : String!) {\n    listenPortsByProtocol (protocol : $protocol) {\n        goid \n        name \n        checksum \n        \n        enabled \n        protocol \n        port \n        hardwiredServiceName \n        enabledFeatures \n        tlsSettings { \n            clientAuthentication \n            keystoreId \n            keyAlias \n            tlsVersions \n            cipherSuites \n            useCipherSuitesOrder \n        } \n        properties { name value }\n\n        hardwiredService {\n            ... on PublishedService {\n                name \n                resolutionPath \n                folderPath \n                methodsAllowed \n                enabled\n            }\n        }\n    }\n}",
+												"variables": "{\n    \"protocol\" : \"HTTPS\"\n}"
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
 							"name": "Mutation",
 							"item": [
 								{
@@ -2371,19 +2547,75 @@
 									"response": []
 								}
 							]
-						},
+						}
+					]
+				},
+				{
+					"name": "Password Policy",
+					"item": [
 						{
-							"name": "Query",
+							"name": "Mutation",
 							"item": [
 								{
-									"name": "All Listen Ports",
+									"name": "Set Password Policies",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
 									"request": {
 										"method": "POST",
 										"header": [],
 										"body": {
 											"mode": "graphql",
 											"graphql": {
-												"query": "query listenPorts {\n    listenPorts {\n        goid \n        name \n        checksum \n        \n        enabled \n        protocol \n        port \n        hardwiredServiceName \n        enabledFeatures \n        tlsSettings { \n            clientAuthentication \n            keystoreId \n            keyAlias \n            tlsVersions \n            cipherSuites \n            useCipherSuitesOrder \n        } \n        properties { name value }\n\n        hardwiredService {\n            ... on PublishedService {\n                name \n                resolutionPath \n                folderPath \n                methodsAllowed \n                enabled\n            }\n        }\n    }\n}",
+												"query": "mutation setPasswordPolicy ($input:[PasswordPolicyInput!]!) {\n    setPasswordPolicies (input: $input) {\n        detailedStatus {\n            status\n            description\n        }\n        passwordPolicies {\n                goid\n                forcePasswordChangeNewUser\n                noRepeatingCharacters\n                minPasswordLength\n                maxPasswordLength\n                upperMinimum\n                lowerMinimum\n                numberMinimum\n                symbolMinimum\n                nonNumericMinimum\n                charDiffMinimum\n                repeatFrequency\n                passwordExpiry\n                allowableChangesPerDay\n                checksum\n        }\n    }\n}",
+												"variables": "{\n  \"input\": [{\n    \"forcePasswordChangeNewUser\" : true,\n    \"noRepeatingCharacters\" : true,\n    \"minPasswordLength\" : 4,\n    \"maxPasswordLength\" : 4,\n    \"upperMinimum\" : 4,\n    \"lowerMinimum\" : 2,\n    \"numberMinimum\" : 2,\n    \"symbolMinimum\" : 2,\n    \"nonNumericMinimum\" : 1,\n    \"charDiffMinimum\" : 5,\n    \"repeatFrequency\" : 3,\n    \"passwordExpiry\": 2,\n    \"allowableChangesPerDay\" : true\n  }]\n}"
+											}
+										},
+										"url": {
+											"raw": "{{target_gw}}",
+											"host": [
+												"{{target_gw}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Query",
+							"item": [
+								{
+									"name": "Get Password Policies",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query passwordPolicies {\n    passwordPolicies {\n        goid\n        forcePasswordChangeNewUser\n        noRepeatingCharacters\n        minPasswordLength\n        maxPasswordLength\n        upperMinimum\n        lowerMinimum\n        numberMinimum\n        symbolMinimum\n        nonNumericMinimum\n        charDiffMinimum\n        repeatFrequency\n        passwordExpiry\n        allowableChangesPerDay\n        checksum\n    }\n}",
 												"variables": ""
 											}
 										},
@@ -2392,49 +2624,8 @@
 											"host": [
 												"{{source_gw}}"
 											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Listen Ports by Name",
-									"request": {
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "graphql",
-											"graphql": {
-												"query": "query listenPortByName ($name : String!) {\n    listenPortByName (name : $name) {\n        goid \n        name \n        checksum \n        \n        enabled \n        protocol \n        port \n        hardwiredServiceName \n        enabledFeatures \n        tlsSettings { \n            clientAuthentication \n            keystoreId \n            keyAlias \n            tlsVersions \n            cipherSuites \n            useCipherSuitesOrder \n        } \n        properties { name value }\n\n        hardwiredService {\n            ... on PublishedService {\n                name \n                resolutionPath \n                folderPath \n                methodsAllowed \n                enabled\n            }\n        }\n    }\n}",
-												"variables": "{\n    \"name\" : \"some-listen-port\"\n}"
-											}
 										},
-										"url": {
-											"raw": "{{source_gw}}",
-											"host": [
-												"{{source_gw}}"
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Listen Ports by Protocol",
-									"request": {
-										"method": "POST",
-										"header": [],
-										"body": {
-											"mode": "graphql",
-											"graphql": {
-												"query": "query listenPortsByProtocol ($protocol : String!) {\n    listenPortsByProtocol (protocol : $protocol) {\n        goid \n        name \n        checksum \n        \n        enabled \n        protocol \n        port \n        hardwiredServiceName \n        enabledFeatures \n        tlsSettings { \n            clientAuthentication \n            keystoreId \n            keyAlias \n            tlsVersions \n            cipherSuites \n            useCipherSuitesOrder \n        } \n        properties { name value }\n\n        hardwiredService {\n            ... on PublishedService {\n                name \n                resolutionPath \n                folderPath \n                methodsAllowed \n                enabled\n            }\n        }\n    }\n}",
-												"variables": "{\n    \"protocol\" : \"HTTPS\"\n}"
-											}
-										},
-										"url": {
-											"raw": "{{source_gw}}",
-											"host": [
-												"{{source_gw}}"
-											]
-										}
+										"description": "# List all Web Api Services\n\nList all of the services\n\nInput: no input"
 									},
 									"response": []
 								}
@@ -2626,6 +2817,158 @@
 											]
 										},
 										"description": "# Policy fragment by guid\n\nGet a policy fragment given its guid (if there is such a policy).\n\nInput: guid"
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Revocation Check Policy",
+					"item": [
+						{
+							"name": "Mutation",
+							"item": [
+								{
+									"name": "Set Revocation Check Policies",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "mutation setRevocationCheckPolicies($input: [RevocationCheckPolicyInput!] !) {\n    setRevocationCheckPolicies(input: $input) {\n        detailedStatus { status description }\n        revocationCheckPolicies {\n            goid\n            name\n            defaultPolicy\n            defaultSuccess\n            continueOnServerUnavailable\n            checksum\n            revocationCheckPolicyItems  {\n                ... on RevocationCheckPolicyItem {\n                    type\n                    url\n                    allowIssuerSignature\n                    nonceUsage\n                    signerThumbprintSha1s\n                    url\n                }\n            }\n        }\n    }\n}",
+												"variables": "{\r\n    \"input\": [{\r\n        \"name\": \"SampleRevocPolicy\",\r\n        \"defaultPolicy\": true,\r\n        \"defaultSuccess\": false,\r\n        \"continueOnServerUnavailable\": false,\r\n        \"revocationCheckPolicyItems\": [{\r\n            \"type\": \"CRL_FROM_URL\",\r\n            \"url\": \"https://test.com\",\r\n            \"allowIssuerSignature\": true,\r\n            \"nonceUsage\": \"EXCLUDE_NONCE\"\r\n        },\r\n        {\r\n            \"type\": \"CRL_FROM_CERTIFICATE\",\r\n            \"url\": \".*\",\r\n            \"allowIssuerSignature\": false,\r\n            \"nonceUsage\": \"INCLUDE_NONCE\"\r\n        },\r\n        {\r\n          \"type\": \"OCSP_FROM_URL\",\r\n          \"url\": \"https://ocspfromurl.com/\",\r\n          \"allowIssuerSignature\": true,\r\n          \"nonceUsage\": \"USE_NONCE_CONDITIONALLY\"\r\n        }]\r\n    }]\r\n}"
+											}
+										},
+										"url": {
+											"raw": "{{target_gw}}",
+											"host": [
+												"{{target_gw}}"
+											]
+										},
+										"description": "# List all Web Api Services\n\nList all of the services\n\nInput: no input"
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Revocation policies",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "mutation deleteRevocationCheckPolicies($input: [String!]!) {\n  deleteRevocationCheckPolicies(names: $input) {\n        detailedStatus { status description } \n\t    revocationCheckPolicies {\n            goid\n            name\n            defaultPolicy\n            defaultSuccess\n            continueOnServerUnavailable\n            checksum         \n            revocationCheckPolicyItems  {\n                ... on RevocationCheckPolicyItem {                    \n                    type\n                    url\n                    allowIssuerSignature\n                    nonceUsage\n                    signerThumbprintSha1s\n                    url\n                }\n            }    \n        }\n    }\n}",
+												"variables": "{\n    \"input\": [\n        \"SampleRevocPolicy\"\n    ]\n}"
+											}
+										},
+										"url": {
+											"raw": "{{target_gw}}",
+											"host": [
+												"{{target_gw}}"
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Query",
+							"item": [
+								{
+									"name": "All Revocation Check Policies",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query revocationPolicies {\n    revocationCheckPolicies {\n        goid\n        name\n        defaultPolicy\n        defaultSuccess\n        continueOnServerUnavailable\n        checksum         \n        revocationCheckPolicyItems  {\n            ... on RevocationCheckPolicyItem {                \n                type\n                url\n                allowIssuerSignature\n                nonceUsage\n                signerThumbprintSha1s\n            }\n        }    \n    }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										},
+										"description": "# List all Web Api Services\n\nList all of the services\n\nInput: no input"
+									},
+									"response": []
+								},
+								{
+									"name": "Revocation Policies By Name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query revocationCheckPolicyByName($name: String!) {\n  revocationCheckPolicyByName(name: $name) {\n        goid\n        name\n        defaultPolicy\n        defaultSuccess\n        continueOnServerUnavailable\n        checksum         \n        revocationCheckPolicyItems  {\n            ... on RevocationCheckPolicyItem {\n                type\n                url\n                allowIssuerSignature\n                nonceUsage\n                signerThumbprintSha1s\n            }\n        }    \n    }\n}",
+												"variables": "{\r\n  \"name\": \"SampleRevocPolicy\"\r\n}"
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										},
+										"description": "# Cluster Properties\n\nGet all the cluster properties\n\nInput: none"
 									},
 									"response": []
 								}
@@ -3110,6 +3453,90 @@
 											]
 										},
 										"description": "# Get key by alias\n\nGet key by alias.\n\nThis is an entry in the gateway keystore. These entries combine a private key and associated certificate and are used for example by listener ports.\n\nThese represent the gateway's own certificates as opposed to the Certificate type which represent a cert trusted by the gateway.\n\nBase64 encoded PKCS12 keystore containing the private key and cert chain for the key entry.  \nThe keystore is password-protected using the transaction encryption passphrase provided."
+									},
+									"response": []
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Service Resolution Config",
+					"item": [
+						{
+							"name": "Mutation",
+							"item": [
+								{
+									"name": "Set Service Resolution Config",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "mutation setServiceResolutionConfigs ($input:[ServiceResolutionConfigInput!]!) {\n    setServiceResolutionConfigs (input: $input) {\n        detailedStatus {\n            status\n            description\n        }\n        serviceResolutionConfigs {\n            goid\n            resolutionPathRequired\n            resolutionPathCaseSensitive\n            useL7OriginalUrl\n            useServiceGoid\n            useSoapAction\n            useSoapBodyChildNamespace\n            checksum\n        }\n    }\n}",
+												"variables": "{\r\n  \"input\": [{\r\n      \"resolutionPathRequired\" : true,\r\n      \"resolutionPathCaseSensitive\" : true,\r\n      \"useL7OriginalUrl\" : true,\r\n      \"useServiceGoid\" : true,\r\n      \"useSoapAction\" : false,\r\n      \"useSoapBodyChildNamespace\" : true\r\n  }]\r\n}"
+											}
+										},
+										"url": {
+											"raw": "{{target_gw}}",
+											"host": [
+												"{{target_gw}}"
+											]
+										},
+										"description": "# Sets the Service Resolution Configuration"
+									},
+									"response": []
+								}
+							]
+						},
+						{
+							"name": "Query",
+							"item": [
+								{
+									"name": "Get Service Resolution Configs",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"protocolProfileBehavior": {
+										"disableBodyPruning": true
+									},
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "graphql",
+											"graphql": {
+												"query": "query serviceResolutionConfigs {\n    serviceResolutionConfigs {\n        goid\n        resolutionPathRequired\n        resolutionPathCaseSensitive\n        useL7OriginalUrl\n        useServiceGoid\n        useSoapAction\n        useSoapBodyChildNamespace\n        checksum\n    }\n}",
+												"variables": ""
+											}
+										},
+										"url": {
+											"raw": "{{source_gw}}",
+											"host": [
+												"{{source_gw}}"
+											]
+										},
+										"description": "# Retrieves Service Resolution Configuration details\n\nInput: no input"
 									},
 									"response": []
 								}
@@ -3743,7 +4170,7 @@
 				"type": "text/javascript",
 				"exec": [
 					"const passphrase = pm.collectionVariables.get(\"passphrase\");",
-					"pm.request.headers.add({key: \"passphrase\", value: passphrase });"
+					"pm.request.headers.add({key: \"l7-passphrase\", value: passphrase });"
 				]
 			}
 		},

--- a/graphman-client/queries/mutation.gql
+++ b/graphman-client/queries/mutation.gql
@@ -2,7 +2,7 @@ mutation applyBundle (
     $clusterProperties: [ClusterPropertyInput!]!=[],
     $webApiServices: [WebApiServiceInput!]!=[],
     $encassConfigs:[EncassConfigInput!]!=[],
-    $revocationCheckPolicies:[RevocationCheckPolicyInput]!=[],
+    $revocationCheckPolicies:[RevocationCheckPolicyInput!]!=[],
     $trustedCerts:[TrustedCertInput!]!=[],
     $dtds:[DtdInput!]!=[],
     $schemas:[SchemaInput!]!=[],

--- a/graphman-client/queries/sysinfo-mutation.gql
+++ b/graphman-client/queries/sysinfo-mutation.gql
@@ -1,0 +1,8 @@
+mutation applyBundle (
+    $administrativeUserAccountProperties: [AdministrativeUserAccountPropertyInput!]!=[],
+    $passwordPolicies: [PasswordPolicyInput!]!=[],
+    $serviceResolutionConfigs:[ServiceResolutionConfigInput!]!=[]) {
+        setAdministrativeUserAccountProperties(input: $administrativeUserAccountProperties) {administrativeUserAccountProperties {goid} detailedStatus {status description}}
+        setPasswordPolicies(input: $passwordPolicies) {passwordPolicies {goid} detailedStatus {status description}}
+        setServiceResolutionConfigs(input: $serviceResolutionConfigs) {serviceResolutionConfigs {goid} detailedStatus {status description}}
+}

--- a/graphman-client/queries/sysinfo-mutation.json
+++ b/graphman-client/queries/sysinfo-mutation.json
@@ -1,0 +1,4 @@
+{
+  "query": "{{sysinfo-mutation.gql}}",
+  "variables": {}
+}

--- a/graphman-client/queries/sysinfo.gql
+++ b/graphman-client/queries/sysinfo.gql
@@ -1,0 +1,11 @@
+query systemAdministration {
+    administrativeUserAccountProperties {
+        {{AdministrativeUserAccountProperty}}
+    }
+    passwordPolicies {
+        {{PasswordPolicy}}
+    }
+    serviceResolutionConfigs {
+        {{ServiceResolutionConfig}}
+    }
+}

--- a/graphman-client/queries/sysinfo.json
+++ b/graphman-client/queries/sysinfo.json
@@ -1,0 +1,4 @@
+{
+  "query": "{{sysinfo.gql}}",
+  "variables": {}
+}

--- a/graphman-client/queries/v10.1-CR03/all.gql
+++ b/graphman-client/queries/v10.1-CR03/all.gql
@@ -90,9 +90,6 @@ query all {
     smConfigs {
         {{SMConfig}}
     }
-    revocationCheckPolicies {
-        {{RevocationCheckPolicy}}
-    }
     trustedCerts {
         {{Certificate}}
     }

--- a/graphman-client/queries/v10.1-CR03/all.json
+++ b/graphman-client/queries/v10.1-CR03/all.json
@@ -1,0 +1,4 @@
+{
+  "query": "{{all.gql}}",
+  "variables": {}
+}

--- a/graphman-client/queries/v10.1-CR03/encass.gql
+++ b/graphman-client/queries/v10.1-CR03/encass.gql
@@ -1,0 +1,17 @@
+query encassByName ($name: String!, $policyName: String!, $includeDirectDependencies: Boolean = false, $includeAllDependencies: Boolean = false) {
+    encassConfigByName (name: $name) {
+        {{EncassConfig}}
+    }
+    policyFragmentByName(name: $policyName) {
+        {{PolicyFragment:-policy}}
+        policy {
+            xml
+            directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency}}
+            }
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency}}
+            }
+        }
+    }
+}

--- a/graphman-client/queries/v10.1-CR03/encass.json
+++ b/graphman-client/queries/v10.1-CR03/encass.json
@@ -1,0 +1,7 @@
+{
+  "query": "{{encass.gql}}",
+  "variables": {
+    "name": "?",
+    "policyName": "?"
+  }
+}

--- a/graphman-client/queries/v10.1-CR03/folder-summary.gql
+++ b/graphman-client/queries/v10.1-CR03/folder-summary.gql
@@ -1,0 +1,28 @@
+query folderSummary ($folderPath: String!) {
+    
+    webApiServicesByFolderPath (folderPath: $folderPath) {
+        {{WebApiService:summary}}
+    }
+    soapServicesByFolderPath (folderPath: $folderPath) {
+        {{SoapService:summary}}
+    }
+	internalWebApiServicesByFolderPath (folderPath: $folderPath) {
+        {{InternalWebApiService:summary}}
+    }
+    internalSoapServicesByFolderPath (folderPath: $folderPath) {
+        {{InternalSoapService:summary}}
+    }
+	encassConfigsByFolderPath (folderPath: $folderPath) {
+        {{EncassConfig:summary}}
+    }
+	globalPoliciesByFolderPath (folderPath: $folderPath) {
+        {{GlobalPolicy:summary}}
+    }
+    backgroundTaskPoliciesByFolderPath (folderPath: $folderPath) {
+        {{BackgroundTaskPolicy:summary}}
+    }
+    policyFragmentsByFolderPath (folderPath: $folderPath) {
+        {{PolicyFragment:summary}}
+    }
+	
+}

--- a/graphman-client/queries/v10.1-CR03/folder.gql
+++ b/graphman-client/queries/v10.1-CR03/folder.gql
@@ -1,0 +1,98 @@
+query folderContents ($folderPath: String!, $includeAllDependencies: Boolean = false, $includeDirectDependencies: Boolean = false) {
+    
+    webApiServicesByFolderPath (folderPath: $folderPath) {
+        {{WebApiService:-policy}}
+        policy {
+            xml
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+			directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+        }
+    }
+	
+    soapServicesByFolderPath (folderPath: $folderPath) {
+        {{SoapService:-policy}}
+        policy {
+            xml
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+			directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+        }
+    }
+	
+	internalWebApiServicesByFolderPath (folderPath: $folderPath) {
+        {{WebApiService:-policy}}
+        policy {
+            xml
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+			directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+        }
+    }
+	
+    internalSoapServicesByFolderPath (folderPath: $folderPath) {
+        {{SoapService:-policy}}
+        policy {
+            xml
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+			directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+        }
+    }
+	
+	encassConfigsByFolderPath (folderPath: $folderPath) {
+        {{EncassConfig}}
+    }
+	
+	globalPoliciesByFolderPath (folderPath: $folderPath) {
+        {{GlobalPolicy:-policy}}
+        policy {
+            xml
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+			directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+        }
+    }
+
+	backgroundTaskPoliciesByFolderPath (folderPath: $folderPath) {
+        {{BackgroundTaskPolicy:-policy}}
+        policy {
+            xml
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+			directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+        }
+    }
+	
+	policyFragmentsByFolderPath (folderPath: $folderPath) {
+        {{PolicyFragment:-policy}}
+        policy {
+            xml
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+			directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency:-policyFragments,encassConfigs}}
+            }
+        }
+    }
+	
+}

--- a/graphman-client/queries/v10.1-CR03/folder.json
+++ b/graphman-client/queries/v10.1-CR03/folder.json
@@ -1,0 +1,6 @@
+{
+  "query": "{{folder.gql}}",
+  "variables": {
+    "folderPath": "?"
+  }
+}

--- a/graphman-client/queries/v10.1-CR03/globalPolicies+scheduledTasks.gql
+++ b/graphman-client/queries/v10.1-CR03/globalPolicies+scheduledTasks.gql
@@ -1,0 +1,12 @@
+query globalPoliciesAndTasks {
+    globalPolicies {
+        {{GlobalPolicy}}
+    }
+    backgroundTaskPolicies {
+        {{BackgroundTaskPolicy}}
+    }
+    scheduledTasks {
+        {{ScheduledTask}}
+    }
+}
+

--- a/graphman-client/queries/v10.1-CR03/globalPolicies+scheduledTasks.json
+++ b/graphman-client/queries/v10.1-CR03/globalPolicies+scheduledTasks.json
@@ -1,0 +1,4 @@
+{
+  "query": "{{globalPolicies+scheduledTasks.gql}}",
+  "variables": {}
+}

--- a/graphman-client/queries/v10.1-CR03/mutation.gql
+++ b/graphman-client/queries/v10.1-CR03/mutation.gql
@@ -2,7 +2,6 @@ mutation applyBundle (
     $clusterProperties: [ClusterPropertyInput!]!=[],
     $webApiServices: [WebApiServiceInput!]!=[],
     $encassConfigs:[EncassConfigInput!]!=[],
-    $revocationCheckPolicies:[RevocationCheckPolicyInput]!=[],
     $trustedCerts:[TrustedCertInput!]!=[],
     $dtds:[DtdInput!]!=[],
     $schemas:[SchemaInput!]!=[],
@@ -31,7 +30,6 @@ mutation applyBundle (
     $serverModuleFiles:[ServerModuleFileInput!]!=[]) {
         setServerModuleFiles(input: $serverModuleFiles){serverModuleFiles{goid} detailedStatus {status description}}
         setClusterProperties (input: $clusterProperties){clusterProperties {goid} detailedStatus {status description}}
-        setRevocationCheckPolicies (input: $revocationCheckPolicies){revocationCheckPolicies {goid} detailedStatus {status description}}
         setTrustedCerts (input: $trustedCerts){trustedCerts {goid} detailedStatus {status description}}
         setSecrets (input: $secrets){secrets{name} detailedStatus {status description}}
         setSchemas (input: $schemas){schemas {goid} detailedStatus {status description}}

--- a/graphman-client/queries/v10.1-CR03/mutation.json
+++ b/graphman-client/queries/v10.1-CR03/mutation.json
@@ -1,0 +1,4 @@
+{
+  "query": "{{mutation.gql}}",
+  "variables": {}
+}

--- a/graphman-client/queries/v10.1-CR03/policyFragment.gql
+++ b/graphman-client/queries/v10.1-CR03/policyFragment.gql
@@ -1,0 +1,14 @@
+query policyFragmentByName ($name: String!, $includeDirectDependencies: Boolean = false, $includeAllDependencies: Boolean = false) {
+    policyFragmentByName (name: $name) {
+        {{PolicyFragment:-policy}}
+        policy {
+            xml
+            directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency}}
+            }
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency}}
+            }
+        }
+    }
+}

--- a/graphman-client/queries/v10.1-CR03/policyFragment.json
+++ b/graphman-client/queries/v10.1-CR03/policyFragment.json
@@ -1,0 +1,6 @@
+{
+  "query": "{{policyFragment.gql}}",
+  "variables": {
+    "name": "?"
+  }
+}

--- a/graphman-client/queries/v10.1-CR03/serverModuleFile.gql
+++ b/graphman-client/queries/v10.1-CR03/serverModuleFile.gql
@@ -1,0 +1,7 @@
+query serverModuleFileByName($name: String!, $includeModuleFilePart: Boolean = false) {
+    serverModuleFileByName(name: $name) {
+        {{ServerModuleFile:-filePartName}}
+        filePartName @include (if: $includeModuleFilePart)
+        checksum
+    }
+}

--- a/graphman-client/queries/v10.1-CR03/serverModuleFile.json
+++ b/graphman-client/queries/v10.1-CR03/serverModuleFile.json
@@ -1,0 +1,6 @@
+{
+  "query": "{{serverModuleFile.gql}}",
+  "variables": {
+    "name": "?"
+  }
+}

--- a/graphman-client/queries/v10.1-CR03/services+policies.gql
+++ b/graphman-client/queries/v10.1-CR03/services+policies.gql
@@ -1,0 +1,23 @@
+query servicesPolicies {
+    webApiServices {
+        {{WebApiService}}
+    }
+    soapServices {
+        {{SoapService}}
+    }
+	internalWebApiServices {
+        {{InternalWebApiService}}
+    }
+    internalSoapServices {
+        {{InternalSoapService}}
+    }
+	globalPolicies {
+        {{GlobalPolicy}}
+    }
+    backgroundTaskPolicies {
+        {{BackgroundTaskPolicy}}
+    }
+	policyFragments {
+        {{PolicyFragment}}
+    }
+}

--- a/graphman-client/queries/v10.1-CR03/services+policies.json
+++ b/graphman-client/queries/v10.1-CR03/services+policies.json
@@ -1,0 +1,4 @@
+{
+  "query": "{{services+policies.gql}}",
+  "variables": {}
+}

--- a/graphman-client/queries/v10.1-CR03/soapService.gql
+++ b/graphman-client/queries/v10.1-CR03/soapService.gql
@@ -1,0 +1,14 @@
+query soapServiceByResolver ($resolver: SoapServiceResolverInput!, $includeDirectDependencies: Boolean = false, $includeAllDependencies: Boolean = false) {
+    soapServiceByResolver (resolver: $resolver) {
+        {{SoapService:-policy}}
+        policy {
+            xml
+            directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency}}
+            }
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency}}
+            }
+        }
+    }
+}

--- a/graphman-client/queries/v10.1-CR03/soapService.json
+++ b/graphman-client/queries/v10.1-CR03/soapService.json
@@ -1,0 +1,6 @@
+{
+  "query": "{{soapService.gql}}",
+  "variables": {
+    "resolver": {}
+  }
+}

--- a/graphman-client/queries/v10.1-CR03/summary.gql
+++ b/graphman-client/queries/v10.1-CR03/summary.gql
@@ -90,9 +90,6 @@ query summary {
     smConfigs {
         {{SMConfig:summary}}
     }
-    revocationCheckPolicies {
-        {{RevocationCheckPolicy}}
-    }
     trustedCerts {
         {{Certificate:summary}}
     }

--- a/graphman-client/queries/v10.1-CR03/summary.json
+++ b/graphman-client/queries/v10.1-CR03/summary.json
@@ -1,0 +1,4 @@
+{
+  "query": "{{summary.gql}}",
+  "variables": {}
+}

--- a/graphman-client/queries/v10.1-CR03/webApiService.gql
+++ b/graphman-client/queries/v10.1-CR03/webApiService.gql
@@ -1,0 +1,14 @@
+query webApiServiceByResolutionPath ($resolutionPath: String!, $includeDirectDependencies: Boolean = false, $includeAllDependencies: Boolean = false) {
+    webApiServiceByResolutionPath (resolutionPath: $resolutionPath) {
+        {{WebApiService:-policy}}
+        policy {
+            xml
+            directDependencies @include (if: $includeDirectDependencies) {
+                {{PolicyDependency}}
+            }
+            allDependencies @include (if: $includeAllDependencies) {
+                {{PolicyDependency}}
+            }
+        }
+    }
+}

--- a/graphman-client/queries/v10.1-CR03/webApiService.json
+++ b/graphman-client/queries/v10.1-CR03/webApiService.json
@@ -1,0 +1,6 @@
+{
+  "query": "{{webApiService.gql}}",
+  "variables": {
+    "resolutionPath": "?"
+  }
+}

--- a/graphman-client/schema/administrativeUserAccountProperties.graphql
+++ b/graphman-client/schema/administrativeUserAccountProperties.graphql
@@ -1,0 +1,49 @@
+extend type Query {
+    "Get all administrative user account minimum properties : logonMaxAllowableAttempts, logonLockoutTime, logonSessionExpiry, logonInactivityPeriod"
+    administrativeUserAccountProperties : [AdministrativeUserAccountProperty!]!
+}
+
+extend type Mutation {
+    """
+    Create or update existing Administrative User Account Minimum cluster properties.
+    If Administrative User Account Minimum cluster property with the given name does not exist, one will be created, otherwise the existing one will be updated.
+    This returns the list of entities created and/or updated.
+    Below are the allowed Administrative User Account Minimum properties
+    logonMaxAllowableAttempts : Logon attempts must be between 1 and 20
+    logonLockoutTime : Lockout period must be between 1 and 86400 seconds
+    logonSessionExpiry : Expiry period must be between 1 and 86400 seconds
+    logonInactivityPeriod : Inactivity period must be between 1 and 365 days
+    """
+    setAdministrativeUserAccountProperties(input: [AdministrativeUserAccountPropertyInput!]!): AdministrativeUserAccountPropertiesPayload!
+
+}
+
+"An Administrative User Account Minimum Property"
+type AdministrativeUserAccountProperty {
+    "The administrative user account minimum property unique identifier"
+    goid: ID
+    "The name of administrative user account minimum property"
+    name: String!
+    "The value of the administrative user account minimum property"
+    value: String!
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+"The inputs sent with the setClusterProperty Mutation"
+input AdministrativeUserAccountPropertyInput {
+    "The administrative user account minimum property unique identifier"
+    goid: ID
+    "The name of administrative user account minimum property"
+    name: String!
+    "The value of the administrative user account minimum property"
+    value: String!
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+type AdministrativeUserAccountPropertiesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    administrativeUserAccountProperties: [AdministrativeUserAccountProperty]!
+}

--- a/graphman-client/schema/clusterinfo.graphql
+++ b/graphman-client/schema/clusterinfo.graphql
@@ -1,0 +1,23 @@
+extend type Query {
+    "Get all cluster nodes information"
+    clusterInfo : ClusterInfo!
+}
+
+type ClusterInfo {
+    "cluster Name"
+    name : String
+    "cluster Nodes Info"
+    nodes : [ClusterNodeInfo!]!
+}
+
+type ClusterNodeInfo {
+    "cluster node id"
+    nodeId : String!
+    "cluster node name"
+    name : String!
+    "cluster node IP Address"
+    address : String!
+    "cluster node uptime"
+    uptime : Int!
+}
+

--- a/graphman-client/schema/idp.graphql
+++ b/graphman-client/schema/idp.graphql
@@ -49,11 +49,17 @@ extend type Mutation {
     "Deletes one or more existing internal groups"
     deleteInternalGroups(names: [String!]!) : InternalGroupsPayload
 
-    "Creates or updates one or more fip users"
+    """
+    Creates or updates one or more fip users.
+    NOTE: Existing user will be found by either login or subjectDn or name.
+    """
     setFipUsers(input: [FipUserInput!]!) : FipUsersPayload
     "Creates or updates one or more fip groups"
     setFipGroups(input: [FipGroupInput!]!) : FipGroupsPayload
-    "Deletes one or more existing fip users"
+    """
+    Deletes one or more existing fip users.
+    NOTE: Here, name can be either login or subjectDn or name.
+    """
     deleteFipUsers(providerName: String!, names: [String!]!) : FipUsersPayload
     "Deletes one or more existing fip groups"
     deleteFipGroups(providerName: String!, names: [String!]!) : FipGroupsPayload

--- a/graphman-client/schema/metadata-base.json
+++ b/graphman-client/schema/metadata-base.json
@@ -1,5 +1,24 @@
 {
   "types": {
+    "AdministrativeUserAccountProperty": {
+      "pluralMethod": "administrativeUserAccountProperties",
+      "singularMethod": "administrativeUserAccountProperties",
+      "idField": "name",
+      "prefix": "administrativeUserAccountProperties"
+    },
+    "PasswordPolicy": {
+      "pluralMethod": "passwordPolicies",
+      "singularMethod": "passwordPolicies",
+      "idField": "goid",
+      "prefix": "passwordPolicies"
+    },
+    "ServiceResolutionConfig": {
+      "pluralMethod": "serviceResolutionConfigs",
+      "singularMethod": "serviceResolutionConfigs",
+      "idField": "goid",
+      "prefix": "serviceResolutionConfigs"
+    },
+
     "ActiveConnector": {
       "pluralMethod": "activeConnectors",
       "singularMethod": "activeConnectorByName",

--- a/graphman-client/schema/passwordpolicy.graphql
+++ b/graphman-client/schema/passwordpolicy.graphql
@@ -1,0 +1,83 @@
+extend type Query {
+    "Get Password Policy"
+    passwordPolicy : PasswordPolicy!
+    "Get Password Policies"
+    passwordPolicies : [PasswordPolicy!]!
+}
+
+type PasswordPolicy {
+    "The internal entity unique identifier"
+    goid : ID!
+    "The configuration checksum"
+    checksum : String!
+    "Force password change for new user and reset"
+    forcePasswordChangeNewUser : Boolean!
+    "To enable/disable no repeating characters"
+    noRepeatingCharacters : Boolean!
+    "Minimum Password Length - Enter the minimum number of characters ranging from 3 to 128 required for the password."
+    minPasswordLength : Int!
+    "Maximum Password Length - Enter the maximum number of characters ranging from 3 to 128 required for the password."
+    maxPasswordLength : Int!
+    "Set the number of uppercase letters that are required for the password. ranging from 1 to 128"
+    upperMinimum : Int!
+    "Set the number of lowercase letters that are required for the password. ranging from 1 to 128"
+    lowerMinimum : Int!
+    "Sets how many numbers (0-9) are required for the password. ranging from 1 to 128"
+    numberMinimum : Int!
+    "Sets how many symbol characters are required for the password. ranging from 1 to 128"
+    symbolMinimum : Int!
+    "Sets how many non numeric characters are required for the password. ranging from 1 to 128"
+    nonNumericMinimum : Int!
+    "Sets how many characters are required for the password. ranging from 1 to 128"
+    charDiffMinimum : Int!
+    "Enter the number of times, between 1 and 50, that a new password must be different from the current password"
+    repeatFrequency : Int!
+    "Days required for the password to be expired. ranging from 1 to 1825"
+    passwordExpiry : Int!
+    "Allow One Password Change Per 24 Hours"
+    allowableChangesPerDay : Boolean!
+}
+
+extend type Mutation {
+    "Set/Update the Password Policies"
+    setPasswordPolicies(input : [PasswordPolicyInput!]!) : PasswordPoliciesPayLoad!
+}
+
+type PasswordPoliciesPayLoad {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    passwordPolicies: [PasswordPolicy]!
+}
+
+input PasswordPolicyInput {
+    "The internal entity unique identifier"
+    goid : ID
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+    "Force password change for new user and reset"
+    forcePasswordChangeNewUser : Boolean!
+    "To enable/disable no repeating characters"
+    noRepeatingCharacters : Boolean!
+    "Minimum Password Length - Enter the minimum number of characters ranging from 3 to 128 required for the password."
+    minPasswordLength : Int!
+    "Maximum Password Length - Enter the maximum number of characters ranging from 3 to 128 required for the password."
+    maxPasswordLength : Int! = 32
+    "Set the number of uppercase letters that are required for the password. ranging from 1 to 128"
+    upperMinimum : Int! = 1
+    "Set the number of lowercase letters that are required for the password. ranging from 1 to 128"
+    lowerMinimum : Int! = 1
+    "Sets how many numbers (0-9) are required for the password. ranging from 1 to 128"
+    numberMinimum : Int! = 1
+    "Sets how many symbol characters are required for the password. ranging from 1 to 128"
+    symbolMinimum : Int! = 1
+    "Sets how many non numeric characters are required for the password. ranging from 1 to 128"
+    nonNumericMinimum : Int! = -1
+    "Sets how many characters are required for the password. ranging from 1 to 128"
+    charDiffMinimum : Int! = 4
+    "Enter the number of times, between 1 and 50, that a new password must be different from the current password"
+    repeatFrequency : Int! = 10
+    "Days required for the password to be expired. ranging from 1 to 1825"
+    passwordExpiry : Int! = 90
+    "Allow One Password Change Per 24 Hours"
+    allowableChangesPerDay : Boolean!
+}

--- a/graphman-client/schema/policyfragment.graphql
+++ b/graphman-client/schema/policyfragment.graphql
@@ -127,6 +127,8 @@ type GlobalPolicy {
     listenPorts: [ListenPort]
     "Policy Fragments"
     policyFragments : [PolicyFragment]
+    "Revocation Check Polices"
+    revocationCheckPolicies: [RevocationCheckPolicy]
     "Schemas in global resources"
     schemas: [Schema]
     secrets : [Secret]
@@ -150,7 +152,7 @@ type GlobalPolicy {
    folderPath: String!
    "The name of the policy. Policies are unique by name."
    name: String!
-   "The guid for this service, if none provided, assigned at creation"
+   "The guid for this policy, if none provided, assigned at creation"
    guid : ID
    "The policy"
    policy: PolicyInput!

--- a/graphman-client/schema/resolutionconfiguration.graphql
+++ b/graphman-client/schema/resolutionconfiguration.graphql
@@ -1,0 +1,55 @@
+extend type Query {
+    "Get Service Resolution Config"
+    serviceResolutionConfig : ServiceResolutionConfig!
+    "Get Service Resolution Configs"
+    serviceResolutionConfigs : [ServiceResolutionConfig!]!
+}
+
+input ServiceResolutionConfigInput {
+    "The internal entity unique identifier"
+    goid : ID
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+    "Only Services with a resolution path are accessible"
+    resolutionPathRequired : Boolean!
+    "Resolution paths are case sensitive"
+    resolutionPathCaseSensitive : Boolean!
+    "Allow resolution by L7-Original-URL header"
+    useL7OriginalUrl : Boolean!
+    "Allow resolution by Service GOID/OID in URLs"
+    useServiceGoid : Boolean!
+    "Use SOAP action"
+    useSoapAction : Boolean!
+    "Use SOAP body child namespace"
+    useSoapBodyChildNamespace : Boolean!
+}
+
+extend type Mutation {
+    "Update Service Resolution Configs"
+    setServiceResolutionConfigs(input : [ServiceResolutionConfigInput!]!) : ServiceResolutionConfigsPayLoad!
+}
+
+type ServiceResolutionConfigsPayLoad {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    serviceResolutionConfigs: [ServiceResolutionConfig]!
+}
+
+type ServiceResolutionConfig {
+    "The internal entity unique identifier"
+    goid : ID!
+    "The configuration checksum"
+    checksum : String!
+    "Only Services with a resolution path are accessible"
+    resolutionPathRequired : Boolean!
+    "Resolution paths are case sensitive"
+    resolutionPathCaseSensitive : Boolean!
+    "Allow resolution by L7-Original-URL header"
+    useL7OriginalUrl : Boolean!
+    "Allow resolution by Service GOID/OID in URLs"
+    useServiceGoid : Boolean!
+    "Use SOAP action"
+    useSoapAction : Boolean!
+    "Use SOAP body child namespace"
+    useSoapBodyChildNamespace : Boolean!
+}

--- a/graphman-client/schema/revocationcheckpolicy.graphql
+++ b/graphman-client/schema/revocationcheckpolicy.graphql
@@ -1,0 +1,108 @@
+extend type Query {
+    "Get all RevocationCheckPolicies"
+    revocationCheckPolicies: [RevocationCheckPolicy!]!
+    "Get the RevocationCheckPolicy by name"
+    revocationCheckPolicyByName(name : String!) : RevocationCheckPolicy
+}
+
+extend type Mutation {
+    """
+    Create or update existing revocation check policies.
+    Match is carried by name. If match is found, it will be updated. Otherwise, it will be created.
+    """
+    setRevocationCheckPolicies(input: [RevocationCheckPolicyInput!]!): RevocationCheckPoliciesPayload!
+
+    "Delete existing revocation policies. Match is carried by name."
+    deleteRevocationCheckPolicies(names: [String!]!): RevocationCheckPoliciesPayload!
+}
+
+enum CertRevocationCheckPropertyType {
+    "Type for checking against a CRL from a URL contained in an X.509 Certificate"
+    CRL_FROM_CERTIFICATE
+    "Type for checking against a CRL from a specified URL"
+    CRL_FROM_URL
+    "Type for OCSP check against a responder URL contained in an X.509 Certificate"
+    OCSP_FROM_CERTIFICATE
+    "Type for OCSP check against a specified responder URL"
+    OCSP_FROM_URL
+}
+
+enum OcspNonceUsage {
+    "To include nonce in OCSP requests"
+    INCLUDE_NONCE
+    "Do not include nonce in OCSP requests"
+    EXCLUDE_NONCE
+    "Let pkix.ocsp.useNonce cluster wide property decide"
+    USE_NONCE_CONDITIONALLY
+}
+
+type RevocationCheckPolicyItem {
+    "Type for Checking OCSP or CRL"
+    type: CertRevocationCheckPropertyType!
+    "If the CRL from URL or OCSP from URL option was selected, enter the URL"
+    url: String
+    "If user permitting the entity that issued the certificate"
+    allowIssuerSignature: Boolean!
+    "Whether to include a nonce in OCSP request"
+    nonceUsage: OcspNonceUsage
+    "The sha1 thumbprint of the certificate"
+    signerThumbprintSha1s: [String!]
+}
+
+type RevocationCheckPolicy {
+    "The goid for this revocation check policy"
+    goid : ID!
+    "Name that describes the revocation checking policy"
+    name: String!
+    "The configuration checksum of this Revocation check policy"
+    checksum : String!
+    "Use as default revocation check policy"
+    defaultPolicy: Boolean!
+    "Succeed if revocation status is unknown"
+    defaultSuccess: Boolean!
+    "Continue processing if server is unavailable"
+    continueOnServerUnavailable: Boolean!
+    "Certificate revocation check properties"
+    revocationCheckPolicyItems: [RevocationCheckPolicyItem!]!
+}
+
+type RevocationCheckPoliciesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    revocationCheckPolicies: [RevocationCheckPolicy]!
+}
+
+input RevocationCheckPolicyItemInput {
+    "Type for Checking OCSP or CRL"
+    type: CertRevocationCheckPropertyType!
+    """
+    If the CRL from URL or OCSP from URL option was selected, enter the URL Otherwise provide regex.
+    CRL_FROM_CERTIFICATE &  OCSP_FROM_CERTIFICATE options uses URL Regex &
+    CRL_FROM_URL & OCSP_FROM_URL options uses URLs.
+    This is caller's responsibility to provide valid URL or Regex, Graphman won't validate it.
+    """
+    url: String!
+    "If user permitting the entity that issued the certificate"
+    allowIssuerSignature: Boolean!
+    "Whether to include a nonce in OCSP request, default is to set INCLUDE_NONCE"
+    nonceUsage: OcspNonceUsage = INCLUDE_NONCE
+    "The sha1 thumbprint of the certificate"
+    signerThumbprintSha1s: [String]
+}
+
+input RevocationCheckPolicyInput {
+    "The goid for this revocation check policy"
+    goid : ID
+    "Name that describes the revocation checking policy"
+    name: String!
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+    "Use as default revocation check policy"
+    defaultPolicy: Boolean!
+    "Succeed if revocation status is unknown"
+    defaultSuccess: Boolean!
+    "Continue processing if server is unavailable"
+    continueOnServerUnavailable: Boolean!
+    "Certificate revocation check properties"
+    revocationCheckPolicyItems: [RevocationCheckPolicyItemInput!]!
+}

--- a/graphman-client/schema/scheduledtask.graphql
+++ b/graphman-client/schema/scheduledtask.graphql
@@ -115,7 +115,7 @@ input BackgroundTaskPolicyInput {
   folderPath: String!
   "The background task policy"
   policy: PolicyInput!
-  soap: Boolean
+  soap: Boolean = false
   "The configuration checksum"
   checksum: String
 }

--- a/graphman-client/schema/soapservice.graphql
+++ b/graphman-client/schema/soapservice.graphql
@@ -40,6 +40,8 @@ enum SoapVersion {
 type SoapService implements PublishedService {
     "The goid for this service"
     goid : ID!
+    "The guid for this service"
+    guid : ID
     "The name of the service"
     name: String!
     "The resolution path to the service"
@@ -73,6 +75,8 @@ type SoapService implements PublishedService {
 type InternalSoapService implements PublishedService {
     "The goid for this service"
     goid : ID!
+    "The guid for this service"
+    guid : ID
     "The name of the service"
     name: String!
     "The resolution path to the service"
@@ -125,6 +129,8 @@ input SoapServiceResolverInput {
 input SoapServiceInput {
     "The internal entity unique identifier"
     goid: ID
+    "The guid for this service, if none provided, assigned at creation"
+    guid: ID
    "The folder path where to create this service.  If the path does not exist, it will be created"
    folderPath: String!
    "The name of the service"

--- a/graphman-client/schema/trustedcert.graphql
+++ b/graphman-client/schema/trustedcert.graphql
@@ -69,23 +69,16 @@ type Certificate {
     trustedFor : [TrustedForType!]!
     "The revocation check policy type"
     revocationCheckPolicyType : PolicyUsageType!
+    "The name of revocation policy.  Required if revocationCheckPolicyType is PolicyUsageType.SPECIFIED"
+    revocationCheckPolicyName : String
     "The specified revocation policy"
     revocationCheckPolicy : RevocationCheckPolicy
-
     "The start date of the validity period"
     notBefore : DateTime!
     "the end date of the validity period"
     notAfter : DateTime!
     "The base 64 encoded string of this certificate"
     certBase64 : String!
-}
-
-"A revocation check policy for certificates"
-type RevocationCheckPolicy {
-    "The goid for this revocation check policy"
-    goid : ID!
-    "The name for this revocation check policy"
-    name : String!
 }
 
 enum PolicyUsageType {

--- a/graphman-client/schema/v10.1-CR03/activeconnector.graphql
+++ b/graphman-client/schema/v10.1-CR03/activeconnector.graphql
@@ -1,0 +1,74 @@
+extend type Query {
+  "Get all active connectors"
+  activeConnectors: [ActiveConnector!]!
+  "Get the active connector by name"
+  activeConnectorByName(name : String!) : ActiveConnector
+  "Get the active connectors by type"
+  activeConnectorsByType(connectorType : ActiveConnectorType!) : [ActiveConnector!]!
+}
+
+extend type Mutation {
+  """
+  Create or update existing active connector.
+  Match is carried by name. If match is found, it will be updated. Otherwise, it will be created.
+  """
+  setActiveConnectors(input: [ActiveConnectorInput!]!): ActiveConnectorsPayload!
+
+  "Delete existing active connector. Match is carried by name."
+  deleteActiveConnectors(names: [String!]!): ActiveConnectorsPayload!
+}
+
+enum ActiveConnectorType {
+    KAFKA
+    SFTP_POLLING_LISTENER
+    MQ_NATIVE
+}
+
+type ActiveConnector {
+    "The goid for the active connector"
+    goid : ID!
+    "The active connector name"
+    name : String!
+    "The configuration checksum of this active connector"
+    checksum : String!
+
+    "Whether this active connector is enabled"
+    enabled : Boolean!
+    "The active connector type - KAFKA, SFTP_POLLING_LISTENER, MQ_NATIVE"
+    connectorType: ActiveConnectorType!
+    "The name of the published service hardwired to the active connector"
+    hardwiredServiceName: String
+    "The active connector Properties"
+    properties: [EntityProperty!]
+    "The advanced properties for active connector"
+    advancedProperties: [EntityProperty!]
+
+    "The published service hardwired to the active connector"
+    hardwiredService: HardwiredService
+}
+
+input ActiveConnectorInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The active connector name"
+    name: String!
+    "Whether this active connector is enabled"
+    enabled: Boolean!
+    "The active connector type - KAFKA, SFTP_POLLING_LISTENER, MQ_NATIVE"
+    connectorType: ActiveConnectorType!
+    "The name of the published service hardwired to the active connector"
+    hardwiredServiceName: String
+    "The active connector properties"
+    properties: [EntityPropertyInput!]
+    "The advanced properties for active connector"
+    advancedProperties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+type ActiveConnectorsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    "The mutated active connectors"
+    activeConnectors: [ActiveConnector]!
+}

--- a/graphman-client/schema/v10.1-CR03/cassandraconn.graphql
+++ b/graphman-client/schema/v10.1-CR03/cassandraconn.graphql
@@ -1,0 +1,96 @@
+extend type Query {
+    "Get all Cassandra Connections"
+    cassandraConnections : [CassandraConnection!]!
+    "Get Cassandra Connection by name"
+    cassandraConnectionByName(name: String!) : CassandraConnection
+    "Get Cassandra Connection by goid"
+    cassandraConnectionByGoid(goid: ID!) : CassandraConnection
+}
+
+extend type Mutation {
+    """
+    Create or update Cassandra connections.
+    If Cassandra connection with the same name exist, the Cassandra connection will be updated.
+    If no Cassandra connection with the name exist, a new Cassandra connection will be created.
+    """
+    setCassandraConnections(input: [CassandraConnectionInput!]!): CassandraConnectionsPayload!
+
+    """
+    Deletes Cassandra connections.
+    """
+    deleteCassandraConnections(
+        "The names of the Cassandra connection to delete"
+        names: [String!]!): CassandraConnectionsPayload!
+}
+
+enum CassandraCompression {
+    NONE
+    LZ4
+}
+
+"A Cassandra Connection"
+type CassandraConnection {
+    "The goid for the Cassandra Connection"
+    goid : ID!
+    "The Cassandra Connection name"
+    name : String!
+    "The configuration checksum of this Cassandra connection"
+    checksum: String!
+
+    "Whether this Cassandra connection is enabled"
+    enabled: Boolean!
+    "The Cassandra keyspace name"
+    keyspace: String!
+    "The Cassandra connection points"
+    contactPoints : [String!]!
+    "The Cassandra server port"
+    port: PositiveInt!
+    "The Cassandra connection compression type"
+    compression: CassandraCompression!
+    "The username"
+    username: String
+    "The secure password reference."
+    securePasswordName: String
+    "Whether this Cassandra connection is SSL enabled"
+    sslEnabled: Boolean!
+    "Cipher suites used for SSL connection"
+    cipherSuites: [String!]
+    "The Cassandra connection properties"
+    properties: [EntityProperty!]
+}
+
+input CassandraConnectionInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The Cassandra Connection name"
+    name : String!
+    "The Cassandra keyspace name"
+    keyspace: String! = ""
+    "The Cassandra connection points"
+    contactPoints : [String!]!
+    "The Cassandra server port"
+    port: PositiveInt!
+    "The username"
+    username: String! = ""
+    "The secure password reference."
+    securePasswordName: String
+    "The Cassandra connection compression type"
+    compression: CassandraCompression = NONE
+    "Whether this Cassandra connection is SSL enabled"
+    sslEnabled: Boolean!
+    "Cipher suites used for SSL connection"
+    cipherSuites: [String!]
+    "Whether this Cassandra connection is enabled"
+    enabled: Boolean!
+    "The Cassandra connection properties"
+    properties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+type CassandraConnectionsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    "The mutated Cassandra connections."
+    cassandraConnections: [CassandraConnection]!
+}

--- a/graphman-client/schema/v10.1-CR03/clusterproperty.graphql
+++ b/graphman-client/schema/v10.1-CR03/clusterproperty.graphql
@@ -1,0 +1,57 @@
+extend type Query {
+  "Get all cluster properties"
+  clusterProperties : [ClusterProperty!]!
+  "Get the cluster property with the given name"
+  clusterPropertyByName(name : String!) : ClusterProperty
+}
+
+extend type Mutation {
+  """
+  Create or update existing cluster properties.  If a cluster property with the given name does not
+  exist, one will be created, otherwise the existing one will be updated. This returns the list of
+  entities created and/or updated
+  """
+  setClusterProperties(input: [ClusterPropertyInput!]!): ClusterPropertiesPayload!
+
+  "Delete existing cluster properties"
+  deleteClusterProperties(names: [String!]!): ClusterPropertiesPayload!
+}
+
+"Cluster properties are used to set global properties"
+type ClusterProperty {
+    "The goid for the cluster property"
+    goid : ID!
+    "The cluster property name"
+    name : String!
+    "The configuration checksum of this cluster prop"
+    checksum: String!
+
+    "The cluster property description"
+    description : String
+    "Whether this is a hidden property"
+    hiddenProperty : Boolean!
+    "The cluster property value"
+    value : String!
+}
+
+"The inputs sent with the setClusterProperty Mutation"
+input ClusterPropertyInput {
+    "The internal entity unique identifier"
+    goid: ID
+  "The name of the cluster property"
+  name: String!
+  "The value of the cluster property to set"
+  value: String!
+  "The cluster property description"
+  description : String
+  "Whether this is a hidden property. (Note that, this field has no effect on the mutation)"
+  hiddenProperty : Boolean
+  "Ignored at creation time but can be used to compare bundle with gw state"
+  checksum : String
+}
+
+type ClusterPropertiesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    clusterProperties: [ClusterProperty]!
+}

--- a/graphman-client/schema/v10.1-CR03/emaillistener.graphql
+++ b/graphman-client/schema/v10.1-CR03/emaillistener.graphql
@@ -1,0 +1,103 @@
+extend type Query {
+  "Get all email listeners"
+  emailListeners : [EmailListener!]!
+  "Get the email listener by name"
+  emailListenerByName(name : String!) : EmailListener
+}
+
+extend type Mutation {
+  """
+  Create or update existing email listeners.
+  Match is carried by name. If match is found, it will be updated. Otherwise, it will be created.
+  """
+  setEmailListeners(input: [EmailListenerInput!]!): EmailListenersPayload!
+
+  "Delete existing email listeners. Match is carried by name."
+  deleteEmailListeners(names: [String!]!): EmailListenersPayload!
+}
+
+enum EmailServerType {
+    IMAP
+    POP3
+}
+
+type EmailListener {
+    "The goid for the email listener Connection"
+    goid : ID!
+    "The name of the email listener. If you are creating several listeners, make sure the name is descriptive"
+    name : String!
+    "The configuration checksum"
+    checksum: String!
+
+    "Whether this email listener is enabled(active)"
+    enabled : Boolean!
+    "The type of email server (IMAP or POP3)"
+    serverType: EmailServerType!
+    "The hostname of the email server. This name is verified against the X.509 certificate"
+    hostname: String!
+    "The port number to monitor"
+    port : PositiveInt!
+    "The folder name to check for emails (Only for IMAP)"
+    folder: String!
+    "Whether delete the messages on the mail server after retrieving"
+    deleteOnReceive: Boolean!
+    "Email account name"
+    username: String!
+    "Email account password. The password could be in plain text or secure password reference"
+    password: String!
+    "The name of the published service hardwired to the email listener"
+    hardwiredServiceName: String
+    "Whether email server connection (POP3S or IMAPS) is SSL enabled"
+    sslEnabled: Boolean!
+    "The listener will check for email after the specified number of seconds"
+    pollInterval: PositiveInt!
+    "Permitted maximum size of the message"
+    sizeLimit: NonNegativeInt
+    "The email listener properties excluding sizeLimit and HardwiredServiceName"
+    properties: [EntityProperty!]
+
+    "The published service hardwired to the email listener"
+    hardwiredService: HardwiredService
+}
+
+input EmailListenerInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The name of the email listener. If you are creating several listeners, make sure the name is descriptive"
+    name: String!
+    "Whether this email listener is enabled(active)"
+    enabled: Boolean!
+    "The hostname of the email server. This name is verified against the X.509 certificate"
+    hostname: NonEmptyString!
+    "The port number to monitor"
+    port: PositiveInt!
+    "The type of email server (IMAP or POP3)"
+    serverType: EmailServerType!
+    "Whether email server connection (POP3S or IMAPS) is SSL enabled"
+    sslEnabled: Boolean!
+    "Whether delete the messages on the mail server after retrieving"
+    deleteOnReceive: Boolean!
+    "The folder name to check for emails (Only for IMAP)"
+    folder: String!
+    "The listener will check for email after the specified number of seconds"
+    pollInterval: PositiveInt!
+    "Email account name"
+    username: String!
+    "Email account password. The password could be in plain text or secure password reference"
+    password: String!
+    "The name of the published service hardwired to the email listener"
+    hardwiredServiceName: String
+    "Permitted maximum size of the message"
+    sizeLimit: NonNegativeInt
+    "[Optional] The Email listener Properties excluding sizeLimit and HardwiredServiceName. When specified, will replace existing properties"
+    properties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+type EmailListenersPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    "The mutated email listener connections."
+    emailListeners: [EmailListener]!
+}

--- a/graphman-client/schema/v10.1-CR03/encass.graphql
+++ b/graphman-client/schema/v10.1-CR03/encass.graphql
@@ -1,0 +1,134 @@
+#
+# The graphman schema for encapsulated assertion configurations
+#
+
+extend type Query {
+    "Get all Encapsulated Assertion Configurations"
+    encassConfigs : [EncassConfig!]!
+    "Get all Encapsulated Assertion Configurations by folder path"
+    encassConfigsByFolderPath(folderPath: String!) : [EncassConfig!]!
+    "Get Encapsulated Assertion Configuration by name"
+    encassConfigByName(name: String!) : EncassConfig
+    "Get Encapsulated Assertion Configuration by goid"
+    encassConfigByGoid(goid: ID!) : EncassConfig
+    "Get Encapsulated Assertion Configuration by guid"
+    encassConfigByGuid(guid: ID!) : EncassConfig
+}
+
+extend type Mutation {
+    "Create or update Encapsulated Assertion Configurations"
+    setEncassConfigs(input: [EncassConfigInput!]!) : EncassConfigsPayload
+    "Delete existing Encapsulated Assertion Configurations"
+    deleteEncassConfigs(names: [String!]!) : EncassConfigsPayload
+}
+
+"An Encapsulated Assertion Configuration"
+type EncassConfig {
+    "The goid for this encass config"
+    goid : ID!
+    "The guid for this encass config"
+    guid : ID!
+    "The name of the encass config"
+    name: String!
+    "The configuration checksum of this encass"
+    checksum: String!
+
+    description: String
+    "The policy it points to and its dependencies"
+    policyName: String!
+    "the input argument descriptions for this encass"
+    encassArgs : [EncassArg!]
+    "the output descriptions"
+    encassResults : [EncassResult!]
+    properties: [EntityProperty!]
+}
+
+"The description of an input argument for an encapsulated assertion"
+type EncassArg {
+    "The name of the input"
+    name: String!
+    # com.l7tech.policy.variable.DataType
+    "The type of input"
+    type : DataType!
+    "The order of the argument in the admin gui"
+    ordinal : Int
+    "The prompt in the admin gui for this encass argument"
+    guiPrompt : Boolean
+    "The label in the admin gui associated with this encass argument"
+    guiLabel : String
+}
+
+"The description of an output from the encapsulated assertion"
+type EncassResult {
+    "The name of the output"
+    name: String!
+    # com.l7tech.policy.variable.DataType
+    "The type of the output"
+    type : DataType!
+}
+
+enum DataType {
+    STRING
+    CERTIFICATE
+    INTEGER
+    DECIMAL
+    FLOAT
+    ELEMENT
+    BOOLEAN
+    BINARY
+    DATE_TIME
+    MESSAGE
+    BLOB
+    CLOB
+    UNKNOWN
+}
+
+"The description of a new encapsulated assertion configuration being created"
+input EncassConfigInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The guid for this encass config, can be omitted and a new one is assigned"
+    guid : ID
+    "The name of the encass config"
+    name: String!
+    description: String
+    "The policy it points to and its dependencies"
+    policyName: String!
+    "the input argument descriptions for this encass"
+    encassArgs : [EncassArgInput!]
+    "the output descriptions"
+    encassResults : [EncassResultInput!]
+    properties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+"The description of an input argument for an encapsulated assertion for use when creating or updating an existing encass config"
+input EncassArgInput {
+    "The name of the input"
+    name: String!
+    # com.l7tech.policy.variable.DataType
+    "The type of input"
+    type : DataType!
+    "The order of the argument in the admin gui"
+    ordinal : Int
+    "The prompt in the admin gui for this encass argument"
+    guiPrompt : Boolean = false
+    "The label in the admin gui associated with this encass argument"
+    guiLabel : String
+}
+
+"The description of an output from the encapsulated assertion for use when creating or updating an existing encass config"
+input EncassResultInput {
+    "The name of the output"
+    name: String!
+    # com.l7tech.policy.variable.DataType
+    "The type of the output"
+    type : DataType!
+}
+
+type EncassConfigsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    encassConfigs: [EncassConfig]!
+}

--- a/graphman-client/schema/v10.1-CR03/globalresource.graphql
+++ b/graphman-client/schema/v10.1-CR03/globalresource.graphql
@@ -1,0 +1,102 @@
+extend type Query {
+    "Get xml schemas configured on this gateway"
+    schemas : [Schema!]!
+    "The schema given its system id"
+    schemaBySystemId(systemId : String!) : Schema
+    "The dtds configured on this gateway"
+    dtds : [Dtd!]!
+    "The dtd given its system id"
+    dtdBySystemId(systemId : String!) : Dtd
+    "Get internal schemas, for reference only"
+    internalSchemas : [Schema!]!
+    "Get internal dtds, for reference only"
+    internalDtds : [Dtd!]!
+}
+
+extend type Mutation {
+    "Create or Update multiple XML schemas"
+    setSchemas(input: [SchemaInput!]!) : SchemasPayload
+    "Delete multiple XML schemas"
+    deleteSchemas(systemIds: [String!]!) : SchemasPayload
+
+    "Create or Update multiple DTD resources"
+    setDtds(input: [DtdInput!]!) : DtdsPayload
+    "Delete multiple DTD resources"
+    deleteDtds(systemIds: [String!]!) : DtdsPayload
+}
+
+"An XML Schema which can be referred to in policy, for example in the validate xml schema assertion"
+type Schema {
+    "Internal goid for this schema"
+    goid : ID!
+    "A reference to the schema. This id is what is referred to in policy and is often mirror of the target namespace"
+    systemId : String!
+    "The configuration checksum"
+    checksum: String!
+
+    "The target namespace in the xml schema"
+    targetNs : String
+    "An optional description for the schema"
+    description : String
+    "The content of XML schema"
+    content : String!
+}
+
+"A Document Type Definition (DTD) which can be referred to in policy"
+type Dtd {
+    "Internal goid for this DTD"
+    goid : ID!
+    "A reference to the DTD. This id is what is referred to in policy and is often mirror of the target namespace"
+    systemId : String!
+    "The configuration checksum"
+    checksum: String!
+
+    "The public id for the DTD"
+    publicId : String
+    "An optional description"
+    description : String
+    "The content of DTD itself"
+    content : String!
+}
+
+input SchemaInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "A reference to the schema. This id is what is referred to in policy and is often mirror of the target namespace"
+    systemId : String!
+    "The target namespace in the XML schema"
+    targetNs : String
+    "An optional description for the schema"
+    description : String
+    "The content of XML schema"
+    content : String!
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+input DtdInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "A reference to the dtd. This id is what is referred to in policy and is often mirror of the target namespace"
+    systemId : String!
+    "The public id for the dtd"
+    publicId : String
+    "An optional description"
+    description : String
+    "The actual dtd itself"
+    content : String!
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+type DtdsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    dtds: [Dtd]!
+}
+
+type SchemasPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    schemas: [Schema]!
+}

--- a/graphman-client/schema/v10.1-CR03/idp.graphql
+++ b/graphman-client/schema/v10.1-CR03/idp.graphql
@@ -1,0 +1,423 @@
+extend type Query {
+    "Get all internal users"
+    internalUsers : [InternalUser!]!
+    "Get all internal groups"
+    internalGroups : [InternalGroup!]!
+    "Get internal user by login"
+    internalUserByLogin(login: String!) : InternalUser
+    "Get internal group by name"
+    internalGroupByName(name: String!) : InternalGroup
+    "Get internal users and groups"
+    searchInternal(filter: IdpFilter!) : InternalSearchResult!
+
+    "Get all fips configurations"
+    fips : [Fip!]!
+    "Get all fip users"
+    fipUsers : [FipUser!]!
+    "Get all fip groups"
+    fipGroups : [FipGroup!]!
+    "Get fip configuration by name"
+    fipByName(name: String!) : Fip
+    "Get fip user by name"
+    fipUserByName(providerName: String!, name: String!) : FipUser
+    "Get fip group by name"
+    fipGroupByName(providerName: String!, name: String!) : FipGroup
+    searchFip(filter: IdpFilter!) : FipSearchResult!
+
+    "Get all ldap configurations"
+    ldaps : [Ldap!]!
+    "Get ldap configuration by name"
+    ldapByName(name: String!) : Ldap
+}
+
+extend type Mutation {
+    "Creates or updates one or more fips"
+    setFips(input: [FipInput!]!) : FipsPayload
+    "Creates or updates one or more ldaps"
+    setLdaps(input: [LdapInput!]!) : LdapsPayload
+    "Deletes one or more existing fips"
+    deleteFips(names: [String!]!) : FipsPayload
+    "Deletes one or more existing ldaps"
+    deleteLdaps(names: [String!]!) : LdapsPayload
+
+    "Creates or updates one or more internal users"
+    setInternalUsers(input: [InternalUserInput!]!) : InternalUsersPayload
+    "Creates or updates one or more internal groups"
+    setInternalGroups(input: [InternalGroupInput!]!) : InternalGroupsPayload
+    "Deletes one or more existing internal users"
+    deleteInternalUsers(logins: [String!]!) : InternalUsersPayload
+    "Deletes one or more existing internal groups"
+    deleteInternalGroups(names: [String!]!) : InternalGroupsPayload
+
+    "Creates or updates one or more fip users"
+    setFipUsers(input: [FipUserInput!]!) : FipUsersPayload
+    "Creates or updates one or more fip groups"
+    setFipGroups(input: [FipGroupInput!]!) : FipGroupsPayload
+    "Deletes one or more existing fip users"
+    deleteFipUsers(providerName: String!, names: [String!]!) : FipUsersPayload
+    "Deletes one or more existing fip groups"
+    deleteFipGroups(providerName: String!, names: [String!]!) : FipGroupsPayload
+}
+
+" Indicate how to search for group or user. Provide either a name pattern, a subject dn and or a goid. "
+input IdpFilter {
+    " The name of the FiP provider, or 'Internal' "
+    providerName : String!
+    "Finds users and groups whose name matches the specified pattern. May include wildcard such as * character"
+    namePattern : String
+    " SubjectDN of a FIP user "
+    subjectDn : String
+    " Get entity by goid "
+    goid : ID
+}
+
+type InternalSearchResult {
+    internalUsers : [InternalUser!]!
+    internalGroups : [InternalGroup!]!
+}
+
+type FipSearchResult {
+    fipUsers : [FipUser!]!
+    fipGroups : [FipGroup!]!
+}
+
+" A group of users defined in the internal identity provider "
+type InternalGroup {
+    goid : ID!
+    name : String!
+    "A checksum of the name, description and member names properties of the group"
+    checksum : String!
+
+    description : String
+    " The list of internal users that are part of this group "
+    members : [InternalUser!]!
+}
+
+input InternalGroupInput {
+    name : String!
+    "If provided, will try to honour at creation time"
+    goid : ID
+    description : String
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+input InternalUserInput {
+    name : String!
+    "If provided, will try to honour at creation time"
+    goid : ID
+    "The list of internal group names that this user is member of. If you pass empty array, will reset memberships. If absent, does not affect memberships for current users."
+    memberOf : [MembershipInput!]
+    login : String!
+    "You can either pass in the hashed password which comes back in queries or the raw passwd directly"
+    password : String
+    "A client-side certificate associated with this user to use for pki type authentication"
+    certBase64 : String
+    firstName : String
+    lastName : String
+    email : String
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+input MembershipInput {
+    name : String!
+}
+
+input FipUserInput {
+    name : String!
+    "If provided, will try to honour at creation time"
+    goid : ID
+    " The name of the FiP this user is defined as part of "
+    providerName : String!
+    "The list of fip group names that this user is member of. If you pass empty array, will reset memberships. If absent, does not affect memberships for current user."
+    memberOf : [MembershipInput!]
+    login : String
+    subjectDn : String
+    "A client-side certificate associated with this user to use for pki type authentication"
+    certBase64 : String
+    firstName : String
+    lastName : String
+    email : String
+    checksum : String
+}
+
+input FipGroupInput {
+    name : String!
+    "If provided, will try to honour at creation time"
+    goid : ID
+    " The name of the FiP this group is defined in "
+    providerName : String!
+    description : String
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+" A user in the internal identity provider "
+type InternalUser {
+    goid : ID!
+    name : String!
+    login : String
+    checksum : String!
+
+    enabled : Boolean!
+    "The hashed password of the user if defined"
+    password : String
+    "A client-side certificate associated with this user to use for pki type authentication"
+    certBase64 : String
+    firstName : String
+    lastName : String
+    email : String
+
+    " List of groups this is member of "
+    memberOf : [InternalGroup!]!
+
+    # possible future expansion expiration, accountExpiration
+}
+
+" A group defined in a federated identity provider"
+type FipGroup {
+    goid : ID!
+    name : String!
+    " The name of the FiP this group is defined in "
+    providerName : String!
+    "A checksum of the name, description and member names properties of the group"
+    checksum : String!
+
+    description : String
+    " Fip users that member of this group "
+    members : [FipUser!]!
+}
+# Note FIP also has concept of virtual group with name, description, subjectDnPattern, emailPattern, isRegex
+
+" A user defined in a federated identity provider "
+type FipUser {
+    goid : ID!
+    name : String!
+    login : String
+    " The name of the FiP this user is defined as part of "
+    providerName : String!
+    checksum : String!
+
+    subjectDn : String
+    "A client-side certificate associated with this user to use for pki type authentication"
+    certBase64 : String
+    firstName : String
+    lastName : String
+    email : String
+    " The list of Fip groups this user belongs to "
+    memberOf : [FipGroup!]!
+}
+
+"A Federated Identity Provider"
+type Fip {
+    goid : ID!
+    name : String!
+    checksum : String!
+
+    enableCredentialTypeSaml : Boolean!
+    enableCredentialTypeX509 : Boolean!
+    certificateValidation: CertificateValidationType
+    " The certificates in the trusted certificate table that establish the trust for this FIP "
+    certificateReferences : [Certificate!]!
+}
+
+input FipInput {
+    name : String!
+    "Will try to match goid if provided"
+    goid : ID
+    enableCredentialTypeSaml : Boolean!
+    enableCredentialTypeX509 : Boolean!
+    certificateValidation: CertificateValidationType
+    " The certificates in the trusted certificate table that establish the trust for this FIP "
+    certificateReferences : [FipCertInput!]!
+    "The optional checksum is ignored during the mutation but can be used to compare bundle content"
+    checksum : String
+}
+
+input LdapInput {
+    name : String!
+    "Will try to match goid if provided"
+    goid : ID
+    ldapUrls : [String!]!
+    "Whether or not the gateway presents a client cert when connecting at those ldap urls (only relevant when ldaps url)"
+    ldapsClientAuthEnabled : Boolean!
+    "The ID of the gateway keystore where the key is located"
+    ldapsClientKeystoreId: ID
+    "The alias of the key in the gateway keystore that is used when doing ldaps client cert authentication"
+    ldapsClientKeyAlias : String
+    searchBase : String!
+    writable : Boolean!
+    bindDn : String!
+    bindPassword : String!
+    userMappings : [UserMappingInput!]!
+    groupMappings : [GroupMappingInput!]!
+    "The optional checksum is ignored during the mutation but can be used to compare bundle content"
+    checksum : String
+}
+
+input FipCertInput {
+    "The thumbprint of the cert to use as trust for a federated identity provider"
+    thumbprintSha1 : String!
+
+    "The internal entity unique identifier. (Note that, this field has no effect on the mutation)"
+    goid: ID
+    "The name of the trusted certificate. (Note that, this field has no effect on the mutation)"
+    name: String
+    "The base 64 encoded string of the certificate. (Note that, this field has no effect on the mutation)"
+    certBase64: String
+    "Whether to perform hostname verification with this certificate. (Note that, this field has no effect on the mutation)"
+    verifyHostname: Boolean
+    "Whether this certificate is a trust anchor. (Note that, this field has no effect on the mutation)"
+    trustAnchor: Boolean
+    "What the certificate is trusted for. (Note that, this field has no effect on the mutation)"
+    trustedFor: [TrustedForType!]
+    "The revocation check policy type. (Note that, this field has no effect on the mutation)"
+    revocationCheckPolicyType : PolicyUsageType
+    "The name of revocation policy. (Note that, this field has no effect on the mutation)"
+    revocationCheckPolicyName : String
+    "The Subject DN of this certificate. (Note that, this field has no effect on the mutation)"
+    subjectDn : String
+    "The start date of the validity period. (Note that, this field has no effect on the mutation)"
+    notBefore : String
+    "the end date of the validity period. (Note that, this field has no effect on the mutation)"
+    notAfter : String
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+type FipsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    fips: [Fip]!
+}
+
+type LdapsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    ldaps: [Ldap]!
+}
+
+type InternalUsersPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    internalUsers: [InternalUser]!
+}
+
+type InternalGroupsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    internalGroups: [InternalGroup]!
+}
+
+type FipUsersPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    fipUsers : [FipUser]!
+}
+
+type FipGroupsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    fipGroups : [FipGroup]!
+}
+
+"""
+LdapIdp config itself is provided. Graphman wont get to
+underlying users and groups in the ldap since they are not
+part of the gateway configuration itself. When l7 policies
+refer to these ldap users and groups, thee references are
+interpreted by the ldap directory itself.
+"""
+type Ldap {
+    goid : ID!
+    name : String!
+    checksum : String!
+
+    ldapUrls : [String!]!
+    "Whether or not the gateway presents a client cert when connecting at those ldap urls (only relevant when ldaps url)"
+    ldapsClientAuthEnabled : Boolean!
+    "The ID of the gateway keystore where the key is located"
+    ldapsClientKeystoreId: ID
+    "The alias of the key in the gateway keystore that is used when doing ldaps client cert authentication"
+    ldapsClientKeyAlias : String
+    searchBase : String!
+    writable : Boolean!
+    bindDn : String!
+    bindPassword : String!
+    userMappings : [UserMapping!]!
+    groupMappings : [GroupMapping!]!
+#   consider these advanced ldap configuration:
+#   userCertificateUseType : UserCertificateUseType!
+#   ntlm stuff, 8 settings and additional arbitrary props
+#   6 additional user cert settings
+}
+
+# enum UserCertificateUseType {
+#    NONE
+#    INDEX
+#    INDEX_CUSTOM
+#    SEARCH
+# }
+
+type GroupMapping {
+    objClass : String!
+    nameAttrName : String!
+    memberAttrName : String!
+    memberStrategy : MemberStrategy!
+}
+
+input GroupMappingInput {
+    objClass : String!
+    nameAttrName : String!
+    memberAttrName : String!
+    memberStrategy : MemberStrategyInput!
+}
+
+type MemberStrategy {
+    "Possible values are 0 for MEMBERS_ARE_DN, 1 MEMBERS_ARE_LOGIN, 2 MEMBERS_ARE_NVPAIR, 3 MEMBERS_BY_OU"
+    val : Int!
+}
+
+input MemberStrategyInput {
+    "Possible values are 0 for MEMBERS_ARE_DN, 1 MEMBERS_ARE_LOGIN, 2 MEMBERS_ARE_NVPAIR, 3 MEMBERS_BY_OU"
+    val : Int!
+}
+
+type UserMapping {
+    objClass : String!
+    nameAttrName : String!
+    loginAttrName : String!
+    passwdAttrName : String
+    firstNameAttrName : String
+    lastNameAttrName : String
+    emailNameAttrName : String
+    kerberosAttrName : String
+    kerberosEnterpriseAttrName : String
+	userCertAttrName : String
+    passwdType : PasswdStrategy!
+}
+
+input UserMappingInput {
+    objClass : String!
+    nameAttrName : String!
+    loginAttrName : String!
+    passwdAttrName : String
+    firstNameAttrName : String
+    lastNameAttrName : String
+    emailNameAttrName : String
+    kerberosAttrName : String
+    kerberosEnterpriseAttrName : String
+	userCertAttrName : String
+    passwdType : PasswdStrategyInput!
+}
+
+type PasswdStrategy {
+    "Possible values are 0 for CLEAR, 1 for HASHED"
+    val : Int!
+}
+
+input PasswdStrategyInput {
+    "Possible values are 0 for CLEAR, 1 for HASHED"
+    val : Int!
+}

--- a/graphman-client/schema/v10.1-CR03/jdbcconn.graphql
+++ b/graphman-client/schema/v10.1-CR03/jdbcconn.graphql
@@ -1,0 +1,125 @@
+extend type Query {
+    "Get all JDBC Connections"
+    jdbcConnections : [JdbcConnection!]!
+    "Get JDBC Connection by name"
+    jdbcConnectionByName(name: String!) : JdbcConnection
+    "Get JDBC Connection by goid"
+    jdbcConnectionByGoid(goid: ID!) : JdbcConnection
+}
+
+extend type Mutation {
+    """
+    Create a JDBC connection.
+    If a JDBC connection with the same name already exists, the creation will fail.
+    NOTE: This is experimental method, likely to be removed or revised in future.
+    """
+    createJdbcConnection(input : JdbcConnectionInput!): JdbcConnectionPayload!
+
+    """
+    Update an existing JDBC connection.
+    If no JDBC connection with the same name exist, the update will fail
+    NOTE: This is experimental method, likely to be removed or revised in future.
+    """
+    updateJdbcConnection(input: JdbcConnectionPartialInput!): JdbcConnectionPayload!
+
+    """
+    Create or update JDBC connections.
+    If JDBC connection with the same name exist, the JDBC connection will be updated.
+    If no JDBC connection with the name exist, a new JDBC connection will be created.
+    """
+    setJdbcConnections(input: [JdbcConnectionInput!]!): JdbcConnectionsPayload!
+
+    """
+    Deletes JDBC connections.
+    """
+    deleteJdbcConnections(
+        "The names of the JDBC connection to delete"
+        names: [String!]!): JdbcConnectionsPayload
+}
+
+"A JDBC Connection"
+type JdbcConnection {
+    "The goid for the JDBC Connection"
+    goid : ID!
+    "The JDBC Connection name"
+    name : String!
+    "The configuration checksum of this JDBC connection"
+    checksum: String!
+
+    "Whether this JDBC connection is enabled"
+    enabled: Boolean!
+    "The JDBC driver class name"
+    driverClass: String!
+    "The JDBC url"
+    jdbcUrl : String!
+    "The username"
+    username: String!
+    "The password or the secure password reference."
+    password: String!
+    "The minimum connection pool size"
+    minPoolSize: NonNegativeInt!
+    "The maximum connection pool size"
+    maxPoolSize: PositiveInt!
+    "The JDBC connection properties excluding 'user' and 'password'"
+    properties: [EntityProperty!]
+}
+
+input JdbcConnectionInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The JDBC Connection name"
+    name : String!
+    "The JDBC driver class name"
+    driverClass: String!
+    "The JDBC url"
+    jdbcUrl : String!
+    "Whether this JDBC connection is enabled"
+    enabled: Boolean! = true
+    "The username"
+    username: String!
+    "The password or the secured password reference"
+    password: String!
+    "The minimum connection pool size"
+    minPoolSize: NonNegativeInt! = 3
+    "The maximum connection pool size"
+    maxPoolSize: PositiveInt! = 15
+    "The JDBC connection properties excluding 'user' and 'password'"
+    properties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+input JdbcConnectionPartialInput {
+    "The JDBC Connection name"
+    name : String!
+    "The JDBC driver class name"
+    driverClass: String
+    "The JDBC url"
+    jdbcUrl : String
+    "Whether this JDBC connection is enabled"
+    enabled: Boolean
+    "The username"
+    username: String
+    "The password or the secured password reference"
+    password: String
+    "The minimum connection pool size"
+    minPoolSize: NonNegativeInt
+    "The maximum connection pool size"
+    maxPoolSize: PositiveInt
+    "The JDBC connection properties excluding 'user' and 'password'.  When specified, will replace all existing properties"
+    properties: [EntityPropertyInput!]
+}
+
+type JdbcConnectionPayload implements EntityMutationPayload {
+    status: EntityMutationStatus!
+    detailedStatus: EntityMutationDetailedStatus!
+    "The created JDBC connection."
+    jdbcConnection: JdbcConnection
+}
+
+type JdbcConnectionsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    "The created/updated JDBC connections."
+    jdbcConnections: [JdbcConnection]!
+}

--- a/graphman-client/schema/v10.1-CR03/jmsdestination.graphql
+++ b/graphman-client/schema/v10.1-CR03/jmsdestination.graphql
@@ -1,0 +1,156 @@
+extend type Query {
+    "Get all JMS Destinations"
+    jmsDestinations : [JmsDestination!]!
+    """
+    Get JMS Destination by name.
+    Here, name can be fully qualified to select JMS destination uniquely.
+    Fully qualified name can be composed as: <JMS DIRECTION>.<JMS PROVIDER TYPE>.<NAME>
+    """
+    jmsDestinationByName(name: String!) : JmsDestination
+    """
+    Get JMS Destinations by name.
+    Here, name can be fully qualified to select JMS destinations accurately.
+    Fully qualified name can be composed as: <JMS DIRECTION>.<JMS PROVIDER TYPE>.<NAME>
+    """
+    jmsDestinationsByName(name: String!) : [JmsDestination!]!
+    "Get JMS Destination by goid"
+    jmsDestinationByGoid(goid: ID!) : JmsDestination
+}
+
+extend type Mutation {
+    """
+    Create or update JMS destinations.
+    If JMS destination exists, the JMS destination will be updated.
+    If no JMS destination with given name, direction, providerType exist, a new JMS destination will be created.
+    """
+    setJmsDestinations(input: [JmsDestinationInput!]!): JmsDestinationsPayload!
+
+    """
+    Deletes JMS destinations. Use simple name or fully qualified name of JMS destinations to delete.
+    """
+    deleteJmsDestinations(
+        names: [String!]!): JmsDestinationsPayload
+}
+
+"A JMS Destination"
+type JmsDestination {
+    "The goid for the JMS Destination"
+    goid : ID!
+    "The goid for the JMS Connection"
+    connectionGoid : ID!
+    "The JMS Destination name"
+    name : String!
+    "The JMS Destination direction (INBOUND or OUTBOUND)"
+    direction: String!
+    "The JMS provider type (GENERIC JMS or TIBCO EMS or WEBSPHERE MQ OVER LDAP or WEBLOGIC JMS"
+    providerType : String!
+    "The configuration checksum of this JMS destination"
+    checksum: String!
+
+    "Whether this JMS destination is enabled"
+    enabled: Boolean!
+    "Whether this JMS destination is template"
+    template: Boolean!
+    "The initial context factory class name"
+    initialContextFactoryClassname: String!
+    "The connection factory name"
+    connectionFactoryName: String!
+    "The JNDI URL"
+    jndiUrl: String!
+    "The JNDI username"
+    jndiUsername: String
+    "The JNDI password"
+    jndiPassword: String
+    "The JNDI SSL details"
+    jndiSslDetails: JmsSslDetails!
+
+    "The destination type"
+    destinationType: String!
+    "The destination name"
+    destinationName: String!
+    "The username for destination connection"
+    destinationUsername: String
+    "The password for destination connection"
+    destinationPassword: String
+    "The destination SSL details"
+    destinationSslDetails: JmsSslDetails!
+
+    "The remaining JMS Destination properties that include inbound options or outbound options or additional properties"
+    properties: [EntityProperty!]
+}
+
+"A JMS SSL Details"
+type JmsSslDetails {
+    "Whether SSL is enabled"
+    sslEnabled: Boolean!
+    "Whether SSL is used for Authentication only"
+    sslForAuthenticationOnly: Boolean!
+    "Whether SSL Server Certificate is to be verified"
+    sslVerifyServerCertificate: Boolean!
+    "Whether SSL Server Hostname is to be verified"
+    sslVerifyServerHostname: Boolean!
+    "Private Key Alias for SSL Client Authentication"
+    sslClientKeyAlias: String
+}
+
+input JmsDestinationInput {
+    "The internal entity unique identifier"
+    goid: ID
+    connectionGoid: ID
+    "The JMS Destination name"
+    name : String!
+    "The JMS Destination direction (inbound or outbound)"
+    direction: String!
+    "The JMS provider type"
+    providerType : String!
+    "The initial context factory class name"
+    initialContextFactoryClassname: String!
+    "The connection factory name"
+    connectionFactoryName: String!
+    "The JNDI URL"
+    jndiUrl: String!
+    "The JNDI username"
+    jndiUsername: String
+    "The JNDI password"
+    jndiPassword: String
+    "The JNDI SSL details"
+    jndiSslDetails: JmsSslDetailsInput
+    "The destination type"
+    destinationType: String!
+    "The destination name"
+    destinationName: String!
+    "The username for destination connection"
+    destinationUsername: String
+    "The password for destination connection"
+    destinationPassword: String
+    "The destination SSL details"
+    destinationSslDetails: JmsSslDetailsInput
+    "Whether this JMS destination is template"
+    template: Boolean!
+    "Whether this JMS destination is enabled"
+    enabled: Boolean!
+    "The remaining JMS Destination properties that include inbound options or outbound options or additional properties"
+    properties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+input JmsSslDetailsInput {
+    "Whether SSL is enabled"
+    sslEnabled: Boolean!
+    "Whether SSL is used for Authentication only"
+    sslForAuthenticationOnly: Boolean!
+    "Whether SSL Server Certificate is to be verified"
+    sslVerifyServerCertificate: Boolean!
+    "Whether SSL Server Hostname is to be verified"
+    sslVerifyServerHostname: Boolean!
+    "Private Key Alias for SSL Client Authentication"
+    sslClientKeyAlias: String
+}
+
+type JmsDestinationsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    "The created/updated JMS destinations."
+    jmsDestinations: [JmsDestination]!
+}

--- a/graphman-client/schema/v10.1-CR03/listenport.graphql
+++ b/graphman-client/schema/v10.1-CR03/listenport.graphql
@@ -1,0 +1,158 @@
+extend type Query {
+    "Get all listen ports"
+    listenPorts : [ListenPort!]!
+    "Get the listen port by name"
+    listenPortByName(name : String!) : ListenPort
+    "Get the listen ports by protocol"
+    listenPortsByProtocol(protocol: String!) : [ListenPort!]!
+}
+
+extend type Mutation {
+    #Create or update existing listen ports.
+    #Match is carried by name. If match is found, it will be updated. Otherwise, it will be created.
+    """
+    Create or update Listen Ports.
+    If Listen Port with the same name exist, the Listen Port will be updated.
+    If no Listen Port with the name exist, a new Listen Port will be created.
+    """
+    setListenPorts(input: [ListenPortInput!]!): ListenPortsPayload!
+
+    "Delete existing listen ports. Match is carried by name."
+    deleteListenPorts(names: [String!]!): ListenPortsPayload!
+}
+
+enum ListenPortFeature {
+    PUBLISHED_SERVICE_MESSAGE_INPUT
+    POLICY_MANAGER_ACCESS
+    ENTERPRISE_MANAGER_ACCESS
+    ADMINISTRATIVE_ACCESS
+    BROWSER_BASED_ADMINISTRATION
+    POLICY_DOWNLOAD_SERVICE
+    PING_SERVICE
+    WS_TRUST_SECURITY_TOKEN_SERVICE
+    CERTIFICATE_SIGNING_SERVICE
+    PASSWORD_CHANGING_SERVICE
+    WSDL_DOWNLOAD_SERVICE
+    SNMP_QUERY_SERVICE
+    BUILT_IN_SERVICES
+    NODE_CONTROL
+    INTER_NODE_COMMUNICATION
+}
+
+enum ListenPortClientAuth {
+    NONE
+    OPTIONAL
+    REQUIRED
+}
+
+type ListenPortTlsSettings {
+    "Specify whether the client must present a certificate to authenticate: NONE/OPTIONAL/REQUIRED"
+    clientAuthentication: ListenPortClientAuth!
+    "Keystore ID"
+    keystoreId: ID
+    "Key alias configured for listen port"
+    keyAlias: String
+    "TLS versions to be enabled for the listen port"
+    tlsVersions: [String!]!
+    "Cipher suites that will be enabled on the SSL listen port"
+    cipherSuites: [String!]
+    "Enforces cipher suites usage in the order of preference"
+    useCipherSuitesOrder: Boolean!
+}
+
+type ListenPort {
+    "The internal entity unique identifier"
+    goid : ID!
+    "The listen port configuration name"
+    name : String!
+    "The configuration checksum"
+    checksum: String!
+
+    "Whether this listen port configuration is enabled"
+    enabled : Boolean!
+    """
+    Protocol (scheme). Possible values are:
+        HTTP
+        HTTPS
+        HTTP2
+        HTTP2 (Secure)
+        FTP
+        FTPS
+        l7.raw.tcp
+        SSH2
+    """
+    protocol: String!
+    """
+    The ListenPort's port number
+    Note: If the listen port is using the SSH2 protocol, avoid using port 22, as it may conflict with the default SSH port 22 on Linux or Unix systems.
+    """
+    port : PositiveInt!
+    "The name of the published service hardwired to the listen port"
+    hardwiredServiceName: String
+    "Which Gateway services can be accessed through this listen port"
+    enabledFeatures: [ListenPortFeature!]!
+    "The listen port tls settings"
+    tlsSettings: ListenPortTlsSettings
+    "The listen port properties"
+    properties: [EntityProperty!]
+
+    "The published service hardwired to the listen port"
+    hardwiredService: HardwiredService
+}
+
+input ListenPortInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The listen port configuration name"
+    name: String!
+    "Whether this listen port configuration is enabled to listen for traffic on the specified port"
+    enabled: Boolean!
+    """
+    Protocol (scheme). Possible values are:
+    HTTP
+    HTTPS
+    HTTP2
+    HTTP2 (Secure)
+    FTP
+    FTPS
+    l7.raw.tcp
+    SSH2
+    """
+    protocol: String!
+    """
+    The ListenPort's port number
+    Note: If the listen port is using the SSH2 protocol, avoid using port 22, as it may conflict with the default SSH port 22 on Linux or Unix systems.
+    """
+    port : PositiveInt!
+    "The name of the published service hardwired to the listen port"
+    hardwiredServiceName: String
+    "Which Gateway services can be accessed through this listen port"
+    enabledFeatures: [ListenPortFeature!]!
+    "The listen port tls settings"
+    tlsSettings: ListenPortTlsSettingsInput
+    "The listen port properties"
+    properties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+input ListenPortTlsSettingsInput {
+    "Specify whether the client must present a certificate to authenticate: NONE/OPTIONAL/REQUIRED"
+    clientAuthentication: ListenPortClientAuth!
+    "Keystore ID"
+    keystoreId: ID
+    "Key alias configured for listen port"
+    keyAlias: String
+    "TLS versions to be enabled for the listen port"
+    tlsVersions: [String!]!
+    "Cipher suites that will be enabled on the SSL listen port"
+    cipherSuites: [String!]
+    "Enforces cipher suites usage in the order of preference"
+    useCipherSuitesOrder: Boolean!
+}
+
+type ListenPortsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    listenPorts: [ListenPort]!
+}

--- a/graphman-client/schema/v10.1-CR03/metadata-base.json
+++ b/graphman-client/schema/v10.1-CR03/metadata-base.json
@@ -1,0 +1,226 @@
+{
+  "types": {
+    "ActiveConnector": {
+      "pluralMethod": "activeConnectors",
+      "singularMethod": "activeConnectorByName",
+      "idField": "name",
+      "prefix": "activeConnector"
+    },
+    "BackgroundTaskPolicy": {
+      "pluralMethod": "backgroundTaskPolicies",
+      "singularMethod": "backgroundTaskPolicyByName",
+      "idField": "name",
+      "prefix": "backgroundTaskPolic"
+    },
+    "CassandraConnection": {
+      "pluralMethod": "cassandraConnections",
+      "singularMethod": "cassandraConnectionByName",
+      "idField": "name",
+      "prefix": "cassandraConnection"
+    },
+    "Certificate": {
+      "pluralMethod": "trustedCerts",
+      "singularMethod": "trustedCertByThumbprint",
+      "idField": "thumbprintSha1",
+      "idFields": ["name", "subjectDn", "thumbprintSha1"],
+      "prefix": "trustedCert"
+    },
+    "ClusterProperty": {
+      "pluralMethod": "clusterProperties",
+      "singularMethod": "clusterPropertyByName",
+      "idField": "name",
+      "prefix": "clusterPropert"
+    },
+    "Dtd": {
+      "pluralMethod": "dtds",
+      "singularMethod": "dtdBySystemId",
+      "idField": "systemId",
+      "prefix": "dtd"
+    },
+    "EmailListener": {
+      "pluralMethod": "emailListeners",
+      "singularMethod": "emailListenerByName",
+      "idField": "name",
+      "prefix": "emailListener"
+    },
+    "EncassConfig": {
+      "pluralMethod": "encassConfigs",
+      "singularMethod": "encassConfigByName",
+      "idField": "name",
+      "prefix": "encassConfig"
+    },
+    "Fip": {
+      "pluralMethod": "fips",
+      "singularMethod": "fipByName",
+      "idField": "name",
+      "prefix": "fip"
+    },
+    "FipGroup": {
+      "pluralMethod": "fipGroups",
+      "singularMethod": "fipGroupByName",
+      "idField": "name",
+      "idFields": [
+        "name",
+        "providerName"
+      ],
+      "prefix": "fipGroup"
+    },
+    "FipUser": {
+      "pluralMethod": "fipUsers",
+      "singularMethod": "fipUserByName",
+      "idField": "name",
+      "idFields": [
+        "name",
+        "providerName"
+      ],
+      "prefix": "fipUser"
+    },
+    "GlobalPolicy": {
+      "pluralMethod": "globalPolicies",
+      "singularMethod": "globalPolicyByTag",
+      "idField": "tag",
+      "idFields": ["name", "tag"],
+      "prefix": "globalPolic"
+    },
+    "InternalGroup": {
+      "pluralMethod": "internalGroups",
+      "singularMethod": "internalGroupByName",
+      "idField": "name",
+      "prefix": "internalGroup"
+    },
+    "InternalSoapService": {
+      "pluralMethod": "internalSoapServices",
+      "singularMethod": "internalSoapServiceByResolutionPath",
+      "idField": "resolutionPath",
+      "prefix": "internalSoapService"
+    },
+    "InternalUser": {
+      "pluralMethod": "internalUsers",
+      "singularMethod": "internalUserByLogin",
+      "idField": "login",
+      "idFields": ["name", "login"],
+      "prefix": "internalUser"
+    },
+    "InternalWebApiService": {
+      "pluralMethod": "internalWebApiServices",
+      "singularMethod": "internalWebApiServiceByResolutionPath",
+      "idField": "resolutionPath",
+      "idFields": ["name", "resolutionPath"],
+      "prefix": "internalWebApiService"
+    },
+    "JdbcConnection": {
+      "pluralMethod": "jdbcConnections",
+      "singularMethod": "jdbcConnectionByName",
+      "idField": "name",
+      "prefix": "jdbcConnection"
+    },
+    "JmsDestination": {
+      "pluralMethod": "jmsDestinations",
+      "singularMethod": "jmsDestinationByName",
+      "idField": "name",
+      "idFields": ["connectionGoid", "name", "direction", "providerType"],
+      "prefix": "jmsDestination"
+    },
+    "Key": {
+      "pluralMethod": "keys",
+      "singularMethod": "keyByAlias",
+      "idField": "alias",
+      "idFields": ["keystoreId", "alias"],
+      "prefix": "key"
+    },
+    "Ldap": {
+      "pluralMethod": "ldaps",
+      "singularMethod": "ldapByName",
+      "idField": "name",
+      "prefix": "ldap"
+    },
+    "ListenPort": {
+      "pluralMethod": "listenPorts",
+      "singularMethod": "listenPortByName",
+      "idField": "name",
+      "prefix": "listenPort"
+    },
+    "PolicyFragment": {
+      "pluralMethod": "policyFragments",
+      "singularMethod": "policyFragmentByName",
+      "idField": "name",
+      "prefix": "policyFragment"
+    },
+    "RevocationCheckPolicy": {
+      "pluralMethod": "revocationCheckPolicies",
+      "singularMethod": "revocationCheckPolicyByName",
+      "idField": "name",
+      "prefix": "revocationCheckPolic"
+    },
+    "SMConfig": {
+      "pluralMethod": "smConfigs",
+      "singularMethod": "smConfigByName",
+      "idField": "name",
+      "prefix": "smConfig"
+    },
+    "ScheduledTask": {
+      "pluralMethod": "scheduledTasks",
+      "singularMethod": "scheduledTaskByName",
+      "idField": "name",
+      "prefix": "scheduledTask"
+    },
+    "Schema": {
+      "pluralMethod": "schemas",
+      "singularMethod": "schemaBySystemId",
+      "idField": "systemId",
+      "prefix": "schema"
+    },
+    "Secret": {
+      "pluralMethod": "secrets",
+      "singularMethod": "secretByName",
+      "idField": "name",
+      "prefix": "secret"
+    },
+    "ServerModuleFile": {
+      "pluralMethod": "serverModuleFiles",
+      "singularMethod": "serverModuleFileByName",
+      "idField": "name",
+      "prefix": "serverModuleFile"
+    },
+    "SoapService": {
+      "pluralMethod": "soapServices",
+      "singularMethod": "soapServiceByResolver",
+      "idField": "resolvers",
+      "idFieldEx": "resolvers { {{SoapResolvers}} }",
+      "idFields": ["name", "resolutionPath", "resolvers { {{SoapResolvers}} }"],
+      "prefix": "soapService"
+    },
+    "WebApiService": {
+      "pluralMethod": "webApiServices",
+      "singularMethod": "webApiServiceByResolutionPath",
+      "idField": "resolutionPath",
+      "idFields": ["name", "resolutionPath"],
+      "prefix": "webApiService"
+    }
+  },
+  "parserHints": {
+    "excludedDataTypes": [
+      "String",
+      "NonEmptyString",
+      "Boolean",
+      "ID",
+      "PositiveInt",
+      "NonNegativeInt",
+      "Int",
+      "DateTime"
+    ],
+    "excludedFields": {
+      "Policy": "directDependencies,allDependencies",
+      "InternalUser": "memberOf",
+      "InternalGroup": "members",
+      "FipUser": "memberOf",
+      "FipGroup": "members",
+      "ServerModuleFile": "filePartName",
+      "EmailListener": "hardwiredService",
+      "ListenPort": "hardwiredService",
+      "ActiveConnector": "hardwiredService"
+    }
+  },
+  "enumTypes": [],
+  "pluralMethods": {}
+}

--- a/graphman-client/schema/v10.1-CR03/policyfragment.graphql
+++ b/graphman-client/schema/v10.1-CR03/policyfragment.graphql
@@ -1,0 +1,198 @@
+extend type Query {
+    "Get all policy fragments"
+    policyFragments : [PolicyFragment!]!
+    "Get policy fragment by name"
+    policyFragmentByName(name: String!) : PolicyFragment
+    "Get policy fragments inside a folder"
+    policyFragmentsByFolderPath(folderPath: String!) : [PolicyFragment!]!
+    "Get policy fragment by goid"
+    policyFragmentByGoid(goid: ID!) : PolicyFragment
+    "Get policy fragment by guid"
+    policyFragmentByGuid(guid: ID!) : PolicyFragment
+    "Get all global policies"
+    globalPolicies : [GlobalPolicy!]!
+    "Get global policy by tag"
+    globalPolicyByTag(tag: String!) : GlobalPolicy
+    "Get global policies inside a folder"
+    globalPoliciesByFolderPath(folderPath: String!) : [GlobalPolicy!]!
+}
+
+extend type Mutation {
+    "Create or update policy fragments"
+    setPolicyFragments(input: [PolicyFragmentInput!]!) : PolicyFragmentsPayload!
+    "Delete policy fragments"
+    deletePolicyFragments(names: [String!]!) : PolicyFragmentsPayload!
+    "Create or update global policies"
+    setGlobalPolicies(input: [GlobalPolicyInput!]!) : GlobalPoliciesPayload!
+    "Delete global policies"
+    deleteGlobalPolicies(tags: [String!]!) : GlobalPoliciesPayload!
+}
+
+"""
+A Global policy
+"""
+type GlobalPolicy {
+    "The goid for this policy"
+    goid : ID!
+    "The guid for this policy"
+    guid : ID!
+    "The name of the policy (policies are unique by name)"
+    name: String!
+    """
+    Global policy tag. Possible values are :
+      message-completed
+      message-received
+      post-security
+      post-service
+      pre-security
+      pre-service
+    """
+    tag: String!
+    "The configuration checksum"
+    checksum: String!
+
+    "The folder path where this policy is located"
+    folderPath: String!
+    "The actual policy and dependencies"
+    policy: Policy!
+}
+
+ """
+ A policy fragment that can be included in another policy
+ """
+ type PolicyFragment {
+    "The goid for this policy"
+    goid : ID!
+    "The guid for this policy"
+    guid : ID!
+    "The name of the policy (policies are unique by name)"
+    name: String!
+    "The configuration checksum"
+    checksum: String!
+
+    "The folder path to the policy"
+    folderPath: String!
+    soap: Boolean
+    "The actual policy and dependencies"
+    policy: Policy!
+ }
+
+ """
+ Wrapper for the policy XML and the dependencies they include
+ """
+ type Policy {
+    "The policy XML"
+    xml: String!
+    "Entities that are directly referred to inside the policy XML"
+    directDependencies: PolicyDependency
+    "Entities that are directly referred to inside the policy XML in addition to ones in policy dependencies. More than second level, this keep going as deep as needed until no dependencies are found"
+    allDependencies: PolicyDependency
+ }
+
+ """
+ Policy Dependency contains all dependencies that may be referred to from the policy XML this is associated with
+ """
+ type PolicyDependency {
+    "Active Connectors (SFTP, MQ Native, Kafka)"
+    activeConnectors: [ActiveConnector]
+    "Cassandra connections"
+    cassandraConnections: [CassandraConnection]
+    "Cluster properties"
+    clusterProperties : [ClusterProperty]
+    "DTDs in global resources"
+    dtds: [Dtd]
+    "Email Listeners"
+    emailListeners: [EmailListener]
+    "Encass Configs"
+    encassConfigs : [EncassConfig]
+    "Federated identity provider configurations"
+    fips : [Fip]
+    "Federated identity provider groups"
+    fipGroups : [FipGroup]
+    "Federated identity provider users"
+    fipUsers : [FipUser]
+    "Internal idp groups"
+    internalGroups : [InternalGroup]
+    "Internal idp users"
+    internalUsers : [InternalUser]
+    "JDBC connections"
+    jdbcConnections: [JdbcConnection]
+    "JMS destinations"
+    jmsDestinations: [JmsDestination]
+    "Private Keys"
+    keys : [Key]
+    "Ldap identity provider configurations"
+    ldaps : [Ldap]
+    "Listen Ports"
+    listenPorts: [ListenPort]
+    "Policy Fragments"
+    policyFragments : [PolicyFragment]
+    "Schemas in global resources"
+    schemas: [Schema]
+    secrets : [Secret]
+    "Server module files (signed modular or custom assertions)"
+    serverModuleFiles: [ServerModuleFile]
+    "Siteminder Configurations"
+    smConfigs: [SMConfig]
+    "Trusted certificates"
+    trustedCerts : [Certificate]
+ }
+
+ input PolicyInput {
+   "The policy xml"
+   xml: String!
+ }
+
+ input PolicyFragmentInput {
+   "The internal entity unique identifier"
+   goid: ID
+   "The folder path where to create this policy.  If the path does not exist, it will be created"
+   folderPath: String!
+   "The name of the policy. Policies are unique by name."
+   name: String!
+   "The guid for this service, if none provided, assigned at creation"
+   guid : ID
+   "The policy"
+   policy: PolicyInput!
+   soap: Boolean = false
+   "Ignored at creation time but can be used to compare bundle with gw state"
+   checksum : String
+ }
+
+input GlobalPolicyInput {
+    "The name of the policy. Policies are unique by name."
+    name: String!
+    "The folder path where to create this policy.  If the path does not exist, it will be created"
+    folderPath: String!
+    "The goid for this policy"
+    goid : ID
+    "The guid for this service, if none provided, assigned at creation"
+    guid : ID
+    """
+    Global policy tag. Possible values are :
+      message-completed
+      message-received
+      post-security
+      post-service
+      pre-security
+      pre-service
+    """
+    tag: String!
+    "The policy"
+    policy: PolicyInput!
+    soap: Boolean = false
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+ type PolicyFragmentsPayload implements EntityMutationsPayload {
+   status: [EntityMutationStatus!]!
+   detailedStatus: [EntityMutationDetailedStatus!]!
+   policyFragments: [PolicyFragment]!
+ }
+
+type GlobalPoliciesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    globalPolicies: [GlobalPolicy]!
+}

--- a/graphman-client/schema/v10.1-CR03/root.graphql
+++ b/graphman-client/schema/v10.1-CR03/root.graphql
@@ -1,0 +1,70 @@
+type Query {
+}
+
+type Mutation {
+}
+
+scalar NonEmptyString
+
+"An Entity Property"
+type EntityProperty {
+    "The name of property"
+    name: String!
+    "The value of the property"
+    value: String!
+}
+
+input EntityPropertyInput {
+    name: String!
+    value: String!
+}
+
+enum EntityMutationStatus {
+    NONE
+    CREATED
+    UPDATED
+    DELETED
+    ERROR
+}
+
+type EntityMutationDetailedStatus {
+    status: EntityMutationStatus!
+    description: String
+}
+
+interface EntityMutationPayload {
+    status: EntityMutationStatus!
+    detailedStatus: EntityMutationDetailedStatus!
+}
+
+interface EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+}
+
+interface PublishedService {
+    "The name of the published service"
+    name: String!
+    "The resolution path for published service"
+    resolutionPath: String
+    "The folder path for published service"
+    folderPath: String!
+    "Which HTTP methods are permitted for incoming requests"
+    methodsAllowed: [HttpMethod!]!
+    "Whether published service is enabled"
+    enabled: Boolean!
+}
+
+union HardwiredService = SoapService | WebApiService
+
+"Support Http methods for Web API Service"
+enum HttpMethod {
+    DELETE
+    HEAD
+    GET
+    POST
+    PUT
+    OPTIONS
+    PATCH
+    OTHER
+}

--- a/graphman-client/schema/v10.1-CR03/scalars.graphql
+++ b/graphman-client/schema/v10.1-CR03/scalars.graphql
@@ -1,0 +1,12 @@
+"An RFC-3339 compliant date time scalar that accepts string values like `1996-12-19T16:39:57-08:00`"
+scalar DateTime
+
+"An Integer that MUST be greater than or equal to zero"
+scalar NonNegativeInt
+
+"An Integer that MUST be greater than zero"
+scalar PositiveInt
+
+#"A File part information from the multi-part message"
+#"This scalar implementation is partial, hence commenting for now"
+#scalar FilePart

--- a/graphman-client/schema/v10.1-CR03/scheduledtask.graphql
+++ b/graphman-client/schema/v10.1-CR03/scheduledtask.graphql
@@ -1,0 +1,133 @@
+extend type Query {
+    "Retrieves all scheduled tasks"
+    scheduledTasks: [ScheduledTask!]!
+    "Retrieves all background task policies"
+    backgroundTaskPolicies: [BackgroundTaskPolicy!]!
+    "Retrieves a scheduled task by name"
+    scheduledTaskByName(name: String!): ScheduledTask
+    "Retrieves a background task policy by name"
+    backgroundTaskPolicyByName(name: String!): BackgroundTaskPolicy
+    "Retrieves background task policies by folder path"
+    backgroundTaskPoliciesByFolderPath(folderPath: String!): [BackgroundTaskPolicy!]!
+}
+
+extend type Mutation {
+    "Creates or updates one or more scheduled tasks"
+    setScheduledTasks(input: [ScheduledTaskInput!]!): ScheduledTasksPayload!
+    "Creates or updates one or more background task policies"
+    setBackgroundTaskPolicies(input: [BackgroundTaskPolicyInput!]!): BackgroundTaskPoliciesPayload!
+    "Deletes one or more existing scheduled tasks"
+    deleteScheduledTasks(names: [String!]!) : ScheduledTasksPayload!
+    "Deletes an existing background task policy"
+    deleteBackgroundTaskPolicies(names: [String!]!) : BackgroundTaskPoliciesPayload!
+}
+
+"Defines a current status of a given scheduled task"
+enum JobStatus {
+    SCHEDULED
+    COMPLETED
+    DISABLED
+}
+
+"Defines a scheduled task type"
+enum JobType {
+    ONE_TIME
+    RECURRING
+}
+
+"A scheduled task"
+type ScheduledTask {
+    "The internal entity unique identifier"
+    goid: ID!
+    "The name of the scheduled task"
+    name: String!
+    "The configuration checksum"
+    checksum: String!
+
+    "The name of the policy for scheduled task"
+    policyName: String!
+    "Scheduled task type"
+    jobType: JobType!
+    "The cron job expression"
+    cronExpression: String
+    "Whether to execute on single node"
+    executeOnSingleNode: Boolean!
+    "Whether to execute the RECURRING task now?"
+    executeOnCreation: Boolean!
+    "Execution date of a ONE_TIME task"
+    executionDate: DateTime
+    "The scheduled task status"
+    status: JobStatus!
+    runAsUser: String
+    runAsUserProviderName: String
+}
+
+"A background task policy that is associated with a scheduled task to be run"
+type BackgroundTaskPolicy {
+    "The internal entity unique identifier"
+    goid: ID!
+    "The internal entity unique identifier"
+    guid: ID!
+    "The name of the background task policy"
+    name: String!
+    "The configuration checksum"
+    checksum: String!
+
+    "The folder path of the background task policy"
+    folderPath: String!
+    soap: Boolean
+    "The background task policy"
+    policy: Policy!
+}
+
+input ScheduledTaskInput {
+  "The internal entity unique identifier"
+  goid: ID
+  "The name of the scheduled task"
+  name: String!
+  "The name of the policy for scheduled task"
+  policyName: String!
+  jobType: JobType!
+  "The cron job expression"
+  cronExpression: String
+  "Whether to execute on single node"
+  executeOnSingleNode: Boolean!
+  "Whether to execute the RECURRING task now?"
+  executeOnCreation: Boolean!
+  "Specify a future execution date for a ONE_TIME task"
+  executionDate: DateTime
+  "The scheduled task status"
+  status: JobStatus = SCHEDULED
+  runAsUser: String
+  runAsUserProviderName: String
+  "The configuration checksum"
+  checksum: String
+}
+
+input BackgroundTaskPolicyInput {
+  "The internal entity unique identifier"
+  goid: ID
+  "The name of the background task policy"
+  name: String!
+  "The internal entity unique identifier"
+  guid: ID
+  "The folder path background task policy"
+  folderPath: String!
+  "The background task policy"
+  policy: PolicyInput!
+  soap: Boolean
+  "The configuration checksum"
+  checksum: String
+}
+
+type ScheduledTasksPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    scheduledTasks: [ScheduledTask]!
+}
+
+type BackgroundTaskPoliciesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    backgroundTaskPolicies: [BackgroundTaskPolicy]!
+}

--- a/graphman-client/schema/v10.1-CR03/secret.graphql
+++ b/graphman-client/schema/v10.1-CR03/secret.graphql
@@ -1,0 +1,145 @@
+extend type Query {
+    "Retrieves all secrets"
+    secrets : [Secret!]!
+    "Retrieves all keys"
+    keys : [Key!]!
+    "Retrieves a secret by name"
+    secretByName(name: String!) : Secret
+    "Retrieves a key by name"
+    keyByAlias(alias: String!) : Key
+}
+
+extend type Mutation {
+    "Creates or updates one or more secrets"
+    setSecrets(input: [SecretInput!]!) : SecretsPayload
+    "Creates or updates one or more keys"
+    setKeys(input: [KeyInput!]!) : KeysPayload
+    "Deletes one or more existing secrets"
+    deleteSecrets(names: [String!]!) : SecretsPayload
+    "Deletes one or more existing keys"
+    deleteKeys(aliases: [String!]!) : KeysPayload
+}
+
+"""
+These secrets are used by gateway policies also for example by jdbc connection configurations
+"""
+type Secret {
+    "The goid for the Secret"
+    goid: ID!
+    """
+    Identify the password being stored. You may use letters, numbers, dashes, and underscores.
+    Names that contain spaces or periods are valid, but the resulting stored password cannot be referenced via context variable.
+    Names that contain @ or $ are valid, but the resulting stored password cannot be referenced via context variable.
+    """
+    name : String!
+    "The configuration checksum"
+    checksum : String!
+
+    "Description of the password. This is optional"
+    description : String
+    """
+    Base64 encrypted secret. The encryption is compatible with openssl secret encryption
+    using cypher AES/CBC/PKCS5Padding. You can decrypt these values at command line
+    using this command:
+    > echo <secret> | openssl enc -d -aes-256-cbc -md sha256 -pass pass:<passphrase> -a
+    """
+    secret : String!
+    "Password or PEM Private Key"
+    secretType : SecretType!
+    "Whether this secret can be referred to in policy via context variable ${secpass... "
+    variableReferencable : Boolean!
+}
+
+enum SecretType {
+    "Stored password for example used in the jdbc connection"
+    PASSWORD
+    "Secure pem key for example used in the route via ssh assertion"
+    PEM_PRIVATE_KEY
+}
+
+"""
+This is an entry in the gateway keystore. These entries combine a private
+key and associated certificate and are used for example by listener ports
+These represent the gateway's own certificates as opposed to the Certificate
+type which represent a cert trusted by the gateway.
+"""
+type Key {
+    "The internal entity unique identifier"
+    goid: ID!
+    "The gateway keystore identifier"
+    keystoreId: ID!
+    "The name assigned to the key"
+    alias : String!
+    "The configuration checksum"
+    checksum : String!
+
+    "The type of the private key"
+    keyType : String!
+    "The subjectDN"
+    subjectDn : String!
+    """
+    Base64 encoded PKCS12 keystore containing the private key and cert chain for the key entry.
+    The keystore is password-protected using the transaction encryption passphrase provided.
+    """
+    p12 : String
+    "The certificate chain in PEM format"
+    certChain : [String!]
+}
+
+input SecretInput {
+    """
+    Identify the password being stored. You may use letters, numbers, dashes, and underscores.
+    Names that contain spaces or periods are valid, but the resulting stored password cannot be referenced via context variable.
+    Names that contain @ or $ are valid, but the resulting stored password cannot be referenced via context variable.
+    """
+    name : String!
+    "Password or PEM Private Key"
+    secretType : SecretType!
+    "The goid for the Secret"
+    goid: ID
+    "Ignored at entity creation time but declared here so you can embed checksums in graphman bundles"
+    checksum : String
+    "Whether this secret can be referred to in policy via context variable ${secpass... "
+    variableReferencable : Boolean!
+    """
+    Base64 encrypted secret. The encryption is compatible with openssl secret encryption
+    using cypher AES/CBC/PKCS5Padding. You can create this value at command line:
+    > echo -n "<clear text secret>" | openssl enc -aes-256-cbc -md sha256 -pass pass:<password> -a
+    """
+    secret : String!
+    "Description of the password. This is optional"
+    description : String
+}
+
+input KeyInput {
+    keystoreId: ID
+    alias : String!
+    """
+    Base64 encoded PKCS12 keystore containing the private key and cert chain for the key entry.
+    The keystore is password-protected using the transaction encryption passphrase provided.
+    """
+    p12 : String
+    "Will try to match at creation time is specified"
+    goid: ID
+    "SubjectDn of the certificate associated with the key. (Note that, this field has no effect on the mutation)"
+    subjectDn : String
+    "Key type. (Note that, this field has no effect on the mutation)"
+    keyType : String
+    "The certificate chain in PEM format. (Note that, this field has no effect on the mutation)"
+    certChain : [String!]
+    "Ignored at entity creation time but declared here so you can embed checksums in graphman bundles"
+    checksum : String
+}
+
+type SecretsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    secrets : [Secret]!
+}
+
+type KeysPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    keys : [Key]!
+}
+

--- a/graphman-client/schema/v10.1-CR03/servermodulefile.graphql
+++ b/graphman-client/schema/v10.1-CR03/servermodulefile.graphql
@@ -1,0 +1,105 @@
+extend type Query {
+    "Get all Server module files"
+    serverModuleFiles : [ServerModuleFile!]!
+    "Get Server module file by name"
+    serverModuleFileByName(name: String!) : ServerModuleFile
+}
+
+extend type Mutation {
+    """
+    Sets Server module files. Updating the existing server module file is unsupported.
+    """
+    setServerModuleFiles(
+        input: [ServerModuleFileInput!]!): ServerModuleFilesPayload
+
+    """
+    Deletes Server module files.
+    """
+    deleteServerModuleFiles(
+        "The names of the Server module file to delete"
+        names: [String!]!): ServerModuleFilesPayload
+}
+
+enum ModuleType {
+    MODULAR_ASSERTION
+    CUSTOM_ASSERTION
+}
+
+"A Server module file"
+type ServerModuleFile {
+    "The goid for the Server module file"
+    goid: ID!
+    "The Server module name"
+    name: String!
+    "The configuration checksum of this Server module file"
+    checksum: String!
+
+    "The Server module type"
+    moduleType: ModuleType!
+    "The Server module SHA256 digest value"
+    moduleSha256: String!
+    "The Server module signature"
+    signature: String!
+    "The base64 encoded signer certificate"
+    signerCertBase64: String!
+    "The Server module file properties"
+    properties: [EntityProperty!]!
+
+    "The Server module file state per node in the cluster"
+    moduleStates: [ServerModuleFileState!]!
+    moduleStateSummary: ServerModuleFileStateSummary!
+    "The dummy field, is used to get the Server module file content in separate part"
+    filePartName: String!
+}
+
+type ServerModuleFileStateSummary {
+    state: ModuleStateSummary!
+    description: String
+}
+
+type ServerModuleFileState {
+    nodeId: String!
+    nodeName: String!
+    state: ModuleState!
+    description: String
+}
+
+enum ModuleStateSummary {
+    LOADING
+    LOADED
+    ERROR
+}
+
+enum ModuleState {
+    UPLOADED
+    ACCEPTED
+    REJECTED
+    LOADED
+    ERROR
+}
+
+input ServerModuleFileInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The Server module name"
+    name: String!
+    "The Server module type"
+    moduleType: ModuleType
+    "The Server module SHA256 digest value"
+    moduleSha256: String
+    "The Server module signature"
+    signature: String
+    "The base64 encoded signer certificate"
+    signerCertBase64: String
+    "The Server module file properties"
+    properties: [EntityPropertyInput!]
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum: String
+}
+
+type ServerModuleFilesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    "The created Server module files."
+    serverModuleFiles: [ServerModuleFile]!
+}

--- a/graphman-client/schema/v10.1-CR03/siteminder.graphql
+++ b/graphman-client/schema/v10.1-CR03/siteminder.graphql
@@ -1,0 +1,98 @@
+extend type Query {
+    "Get all siteminder configurations"
+    smConfigs : [SMConfig!]!
+    "Get the siteminder configuration by name"
+    smConfigByName(name : String!) : SMConfig
+}
+
+extend type Mutation {
+    """
+    Create or update existing siteminder configurations.
+    Match is carried by name. If match is found, it will be updated. Otherwise, it will be created
+    """
+    setSMConfigs(input: [SMConfigInput!]!): SMConfigsPayload!
+
+    "Delete existing siteminder configurations. Match is carried by name"
+    deleteSMConfigs(names: [String!]!): SMConfigsPayload!
+}
+
+enum SMCryptoMode {
+    COMPAT
+    MIGRATE
+    FIPS
+}
+
+type SMConfig {
+    "The goid for the CA SSO connection"
+    goid : ID!
+    "Name of the CA SSO configuration"
+    name : String!
+    "The configuration checksum"
+    checksum: String!
+
+    "Indicates whether the specified configuration is currently enabled or disabled"
+    enabled : Boolean!
+    "Name of the host registered with the CA SSO Policy Server"
+    agentHost: String!
+    "The IP address of the CA SSO agent. This field is required if the Check IP check box is selected"
+    agentIP: String!
+    "CA SSO Policy Server host configuration used by the agent"
+    agentHostConfig: String!
+    "CA SSO shared secret used by the agent to establish communication with the Policy Server"
+    agentSecret: String!
+    "Choose the FIPS mode supported by the CA SSO Policy Server. The available values are: COMPAT(default)/MIGRATE/ONLY"
+    cryptoMode: SMCryptoMode!
+    "The CA SSO Policy Server compare the client IP against the address stored in the SSO Token"
+    ipCheckEnabled: Boolean!
+    "Whether to update the SSO Token after successful authentication/authorization"
+    updateSSOToken: Boolean!
+    "The percentage of servers within a cluster that must be available for Policy Server requests"
+    clusterFailoverThreshold: PositiveInt!
+    nonClusterFailover: Boolean!
+    "User name of the CA SSO administrator"
+    username: String!
+    "The secure password reference"
+    securePasswordName: String!
+    "The Siteminder configuration properties"
+    properties: [EntityProperty!]
+}
+
+input SMConfigInput {
+    "The goid for the CA SSO connection"
+    goid: ID
+    "Name of the CA SSO configuration"
+    name: String!
+    "Indicates whether the specified configuration is currently enabled or disabled"
+    enabled: Boolean!
+    "Name of the host registered with the CA SSO Policy Server"
+    agentHost: String!
+    "The IP address of the CA SSO agent. This field is required if the Check IP check box is selected"
+    agentIP: String!
+    "CA SSO Policy Server host configuration used by the agent"
+    agentHostConfig: String!
+    "CA SSO shared secret used by the agent to establish communication with the Policy Server"
+    agentSecret: String!
+    "Choose the FIPS mode supported by the CA SSO Policy Server. The available values are: COMPAT(default)/MIGRATE/ONLY"
+    cryptoMode: SMCryptoMode!
+    "The CA SSO Policy Server compare the client IP against the address stored in the SSO Token"
+    ipCheckEnabled: Boolean!
+    "Whether to update the SSO Token after successful authentication/authorization"
+    updateSSOToken: Boolean!
+    "The percentage of servers within a cluster that must be available for Policy Server requests"
+    clusterFailoverThreshold: PositiveInt!
+    nonClusterFailover: Boolean!
+    "User name of the CA SSO administrator"
+    username: String!
+    "The secure password reference"
+    securePasswordName: String!
+    "The Siteminder configuration properties"
+    properties: [EntityPropertyInput!]
+    "The configuration checksum"
+    checksum : String
+}
+
+type SMConfigsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    smConfigs: [SMConfig]!
+}

--- a/graphman-client/schema/v10.1-CR03/soapservice.graphql
+++ b/graphman-client/schema/v10.1-CR03/soapservice.graphql
@@ -1,0 +1,164 @@
+extend type Query {
+    "Get all soap services"
+    soapServices : [SoapService]!
+    "Get all Internal soap services"
+    internalSoapServices : [InternalSoapService]!
+    "Get soap services by name"
+    soapServicesByName(name: String!) : [SoapService]!
+    "Get soap service by name. Returns none if more than one are found."
+    soapServiceByName(name: String!) : SoapService
+    "Get Internal soap service by name. Returns none if more than one are found."
+    internalSoapServiceByName(name: String!) : InternalSoapService
+    "Get soap services inside a folder"
+    soapServicesByFolderPath(folderPath: String!) : [SoapService]!
+    "Get Internal soap services inside a folder"
+    internalSoapServicesByFolderPath(folderPath: String!) : [InternalSoapService]!
+    "Get soap service by goid"
+    soapServiceByGoid(goid: ID!) : SoapService
+    "Get soap service by resolver"
+    soapServiceByResolver(resolver: SoapServiceResolverInput!) : SoapService
+}
+
+extend type Mutation {
+    "Create or update soap services"
+    setSoapServices(input: [SoapServiceInput!]!) : SoapServicesPayload
+    "Create or update Internal soap services"
+    setInternalSoapServices(input: [SoapServiceInput!]!) : InternalSoapServicesPayload
+    "Delete existing soap services given their resolution details"
+    deleteSoapServices(resolvers: [SoapServiceResolverInput!]!) : SoapServicesPayload
+    "Delete existing Internal soap services given their resolution details"
+    deleteInternalSoapServices(resolvers: [SoapServiceResolverInput!]!) : InternalSoapServicesPayload
+}
+
+enum SoapVersion {
+    SOAP_1_1
+    SOAP_1_2
+    UNKNOWN
+}
+
+"A Soap service published on the Layer7 Gateway"
+type SoapService implements PublishedService {
+    "The goid for this service"
+    goid : ID!
+    "The name of the service"
+    name: String!
+    "The resolution path to the service"
+    resolutionPath: String
+    "Soap service resolvers"
+    resolvers: SoapResolvers!
+    "The configuration checksum"
+    checksum: String!
+
+    "Whether or not the published service is enabled"
+    enabled: Boolean!
+    "The folder path to the service"
+    folderPath: String!
+    "Which SOAP version"
+    soapVersion: SoapVersion!
+    "Which http methods are allowed if not just POST"
+    methodsAllowed: [HttpMethod!]!
+    tracingEnabled: Boolean!
+    wssProcessingEnabled: Boolean!
+    "Allow requests intended for operations not supported by the WSDL"
+    laxResolution: Boolean
+    properties: [EntityProperty!]
+
+    "The WSDL of the soap service"
+    wsdl: String!
+    "The policy and dependencies"
+    policy: Policy!
+}
+
+"A Soap service published on the Layer7 Gateway"
+type InternalSoapService implements PublishedService {
+    "The goid for this service"
+    goid : ID!
+    "The name of the service"
+    name: String!
+    "The resolution path to the service"
+    resolutionPath: String
+    "Soap service resolvers"
+    resolvers: SoapResolvers!
+    "The configuration checksum"
+    checksum: String!
+
+    "Whether or not the published service is enabled"
+    enabled: Boolean!
+    "The folder path to the service"
+    folderPath: String!
+    "Which SOAP version"
+    soapVersion: SoapVersion!
+    "Which http methods are allowed if not just POST"
+    methodsAllowed: [HttpMethod!]!
+    tracingEnabled: Boolean!
+    wssProcessingEnabled: Boolean!
+    "Allow requests intended for operations not supported by the WSDL"
+    laxResolution: Boolean
+    properties: [EntityProperty!]
+
+    "The WSDL of the soap service"
+    wsdl: String!
+    "The policy and dependencies"
+    policy: Policy!
+}
+
+" Must have minimum (1 soapAction + baseUri) OR resolutionPath. You can have both too. "
+type SoapResolvers {
+    "The soap actions referred to in the wsdl"
+    soapActions: [String!]!
+    "Base uri from the wsdl of the service. This is used for service resolution"
+    baseUri: String
+    "The resolution path to the service if not default /ssg/soap"
+    resolutionPath: String
+}
+
+" Must have minimum (1 soapAction + baseUri) OR resolutionPath. You can have both too. "
+input SoapServiceResolverInput {
+   "One of the SoapAction of the service to resolved. This must be specified along with a base ns from the WSDL"
+   soapAction: String
+   "Base uri from the wsdl of the service. Use this alongside the soapaction property to resolve a soap service without resolutionUri"
+   baseUri: String
+   "The resolution path of the service if that is how the soap service is resolved"
+   resolutionPath: String
+}
+
+input SoapServiceInput {
+    "The internal entity unique identifier"
+    goid: ID
+   "The folder path where to create this service.  If the path does not exist, it will be created"
+   folderPath: String!
+   "The name of the service"
+   name: String!
+   "The WSDL of the soap service"
+   wsdl: String!
+   "The resolution path of the service"
+   resolutionPath: String
+   "The policy"
+   policy: PolicyInput!
+   "Whether the service is enabled (optional, default true)"
+   enabled: Boolean = true
+   "The http methods allowed for this service"
+   methodsAllowed: [HttpMethod!]!
+   "Which SOAP version"
+   soapVersion: SoapVersion = UNKNOWN
+   "Whether or not the gateway should process incoming ws-security soap headers"
+   wssProcessingEnabled: Boolean!
+   tracingEnabled: Boolean = false
+   "Allow requests intended for operations not supported by the WSDL"
+   laxResolution: Boolean = false
+   properties: [EntityPropertyInput!]
+   "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+type SoapServicesPayload implements EntityMutationsPayload {
+  status: [EntityMutationStatus!]!
+  detailedStatus: [EntityMutationDetailedStatus!]!
+  soapServices: [SoapService]!
+}
+
+type InternalSoapServicesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    internalSoapServices: [InternalSoapService]!
+}

--- a/graphman-client/schema/v10.1-CR03/trustedcert.graphql
+++ b/graphman-client/schema/v10.1-CR03/trustedcert.graphql
@@ -1,0 +1,124 @@
+extend type Query {
+    "Retrieves all trusted certificates"
+    trustedCerts : [Certificate!]!
+    "Retrieves a list of trusted certificates with the matching subject dn"
+    trustedCertsByDn(subjectDn : String!) : [Certificate]!
+    "The trusted certificate associated with this unique thumbprint"
+    trustedCertByThumbprint(thumbprintSha1: String!) : Certificate
+}
+
+extend type Mutation {
+    """
+    Create or update trusted certificates.
+    If a certificate with the same sha1 thumbprint already exist, it will be updated.
+    """
+    setTrustedCerts(input: [TrustedCertInput!]!): TrustedCertsPayload!
+
+    "Delete an existing certificates"
+    deleteTrustedCerts(thumbprintSha1s: [String!]!): TrustedCertsPayload!
+}
+
+"Input sent with createTrustedCert mutation"
+input TrustedCertInput {
+    "The internal entity unique identifier"
+    goid: ID
+    "The name of the trusted certificate"
+    name: String!
+    "The base 64 encoded string of the certificate"
+    certBase64: String!
+    "Whether to perform hostname verification with this certificate"
+    verifyHostname: Boolean!
+    "Whether this certificate is a trust anchor"
+    trustAnchor: Boolean!
+    "What the certificate is trusted for"
+    trustedFor: [TrustedForType!]!
+    "The revocation check policy type"
+    revocationCheckPolicyType : PolicyUsageType!
+    "The name of revocation policy.  Required if revocationCheckPolicyType is PolicyUsageType.SPECIFIED"
+    revocationCheckPolicyName : String
+    "The Subject DN of this certificate. (Note that, this field has no effect on the mutation)"
+    subjectDn : String
+    "The start date of the validity period. (Note that, this field has no effect on the mutation)"
+    notBefore : String
+    "the end date of the validity period. (Note that, this field has no effect on the mutation)"
+    notAfter : String
+    "The sha1 thumbprint of the certificate. (Note that, this field has no effect on the mutation)"
+    thumbprintSha1 : String
+    "Ignored at creation time but can be used to compare bundle with gw state"
+    checksum : String
+}
+
+"An certificate that is trusted by the Gateway"
+type Certificate {
+    "The goid for this certificate"
+    goid : ID!
+    "The name"
+    name: String!
+    "The Subject DN of this certificate"
+    subjectDn : String!
+    "The sha1 thumbprint of the certificate"
+    thumbprintSha1 : String!
+    "The configuration checksum of this trusted certificate"
+    checksum: String!
+
+    "Whether to perform hostname verification with this certificate"
+    verifyHostname : Boolean!
+    "Whether this certificate is a trust anchor"
+    trustAnchor : Boolean!
+    "The certificate is trusted for"
+    trustedFor : [TrustedForType!]!
+    "The revocation check policy type"
+    revocationCheckPolicyType : PolicyUsageType!
+    "The specified revocation policy"
+    revocationCheckPolicy : RevocationCheckPolicy
+
+    "The start date of the validity period"
+    notBefore : DateTime!
+    "the end date of the validity period"
+    notAfter : DateTime!
+    "The base 64 encoded string of this certificate"
+    certBase64 : String!
+}
+
+"A revocation check policy for certificates"
+type RevocationCheckPolicy {
+    "The goid for this revocation check policy"
+    goid : ID!
+    "The name for this revocation check policy"
+    name : String!
+}
+
+enum PolicyUsageType {
+    "Do not perform revocation check"
+    NONE
+    "Use the default revocation check policy"
+    USE_DEFAULT
+    "Use the specified revocation check policy"
+    SPECIFIED
+}
+
+"Defines what a certificate is trusted for"
+enum TrustedForType {
+    "Is trusted as an SSL server cert"
+    SSL
+    "Is trusted as a CA that signs SSL server certs"
+    SIGNING_SERVER_CERTS
+    "Is trusted as a CA that signs SSL client certs"
+    SIGNING_CLIENT_CERTS
+    "Is trusted to sign SAML tokens"
+    SAML_ISSUER
+    "Is trusted as a SAML attesting entity"
+    SAML_ATTESTING_ENTITY
+}
+
+enum CertificateValidationType {
+    CERTIFICATE_ONLY
+    PATH_VALIDATION
+    REVOCATION
+}
+
+type TrustedCertsPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    trustedCerts: [Certificate]!
+}

--- a/graphman-client/schema/v10.1-CR03/webapiservice.graphql
+++ b/graphman-client/schema/v10.1-CR03/webapiservice.graphql
@@ -1,0 +1,118 @@
+extend type Query {
+  "Get all webApi services"
+  webApiServices : [WebApiService]!
+  internalWebApiServices : [InternalWebApiService]!
+  "Get webApi services by name"
+  webApiServicesByName(name: String!) : [WebApiService!]!
+  "Get webApi service by name. Returns none if more than one are found."
+  webApiServiceByName(name: String!) : WebApiService
+  "Get Internal webApi Service by name"
+  internalWebApiServiceByName(name: String!) : InternalWebApiService
+  "Get webApi services by resolutionPath"
+  webApiServicesByResolutionPath(resolutionPath: String!) : [WebApiService !]!
+  "Get webApi service by resolutionPath. Returns none if more than one are found."
+  webApiServiceByResolutionPath(resolutionPath: String!) : WebApiService
+  "Get Internal webApi Services by resolutionPath"
+  internalWebApiServiceByResolutionPath(resolutionPath: String!) : InternalWebApiService
+  "Get webApi services inside a folder"
+  webApiServicesByFolderPath(folderPath: String!) : [WebApiService]!
+  "Get Internal webApi services inside a folder"
+  internalWebApiServicesByFolderPath(folderPath: String!) : [InternalWebApiService]!
+  "Get webApi services by goid"
+  webApiServiceByGoid(goid: ID!) : WebApiService
+}
+
+extend type Mutation {
+  "Create or update web api services"
+  setWebApiServices(input: [WebApiServiceInput!]!) : WebApiServicesPayload
+  "Create or update Internal web api services"
+  setInternalWebApiServices(input: [WebApiServiceInput!]!) : InternalWebApiServicesPayload
+  "Delete existing web api services given their resolution paths"
+  deleteWebApiServices(resolutionPaths: [String!]!) : WebApiServicesPayload
+  "Delete existing Internal web api services given their resolution paths"
+  deleteInternalWebApiServices(resolutionPaths: [String!]!) : InternalWebApiServicesPayload
+}
+
+"A Web API service published on the Layer7 Gateway"
+type WebApiService implements PublishedService {
+    "The goid for this service"
+    goid : ID!
+    "The name of the service"
+    name: String!
+    "The resolution path to the service"
+    resolutionPath: String!
+    "The configuration checksum"
+    checksum: String!
+
+    "Whether or not the published service is enabled"
+    enabled: Boolean!
+    "The folder path to the service"
+    folderPath: String!
+    "Which http methods are allowed"
+    methodsAllowed: [HttpMethod!]!
+    tracingEnabled: Boolean!
+    wssProcessingEnabled: Boolean!
+    properties: [EntityProperty!]
+
+    "The policy and dependencies"
+    policy: Policy!
+}
+
+"A Internal Web API service published on the Layer7 Gateway"
+type InternalWebApiService implements PublishedService {
+    "The goid for this service"
+    goid : ID!
+    "The name of the service"
+    name: String!
+    "The resolution path to the service"
+    resolutionPath: String!
+    "The configuration checksum"
+    checksum: String!
+
+    "Whether or not the published service is enabled"
+    enabled: Boolean!
+    "The folder path to the service"
+    folderPath: String!
+    "Which http methods are allowed"
+    methodsAllowed: [HttpMethod!]!
+    tracingEnabled: Boolean!
+    wssProcessingEnabled: Boolean!
+    properties: [EntityProperty!]
+
+    "The policy and dependencies"
+    policy: Policy!
+}
+
+input WebApiServiceInput {
+  "The internal entity unique identifier"
+  goid: ID
+  "The folder path where to create this service.  If the path does not exist, it will be created"
+  folderPath: NonEmptyString!
+  "The name of the service"
+  name: String!
+  "The resolution path of the service"
+  resolutionPath: String!
+  "The policy"
+  policy: PolicyInput!
+  "Whether the service is enabled (optional, default to true)"
+  enabled: Boolean = true
+  "The http methods allowed for this service"
+  methodsAllowed: [HttpMethod!]!
+  tracingEnabled: Boolean = false
+  wssProcessingEnabled: Boolean = false
+  properties: [EntityPropertyInput!]
+  "Ignored at creation time but can be used to compare bundle with gw state"
+  checksum : String
+}
+
+type WebApiServicesPayload implements EntityMutationsPayload {
+  status: [EntityMutationStatus!]!
+  detailedStatus: [EntityMutationDetailedStatus!]!
+  webApiServices: [WebApiService]!
+}
+
+type InternalWebApiServicesPayload implements EntityMutationsPayload {
+    status: [EntityMutationStatus!]!
+    detailedStatus: [EntityMutationDetailedStatus!]!
+    internalWebApiServices: [InternalWebApiService]!
+}

--- a/graphman-client/schema/webapiservice.graphql
+++ b/graphman-client/schema/webapiservice.graphql
@@ -37,6 +37,8 @@ extend type Mutation {
 type WebApiService implements PublishedService {
     "The goid for this service"
     goid : ID!
+    "The guid for this service"
+    guid : ID
     "The name of the service"
     name: String!
     "The resolution path to the service"
@@ -62,6 +64,8 @@ type WebApiService implements PublishedService {
 type InternalWebApiService implements PublishedService {
     "The goid for this service"
     goid : ID!
+    "The guid for this service"
+    guid : ID
     "The name of the service"
     name: String!
     "The resolution path to the service"
@@ -86,6 +90,8 @@ type InternalWebApiService implements PublishedService {
 input WebApiServiceInput {
   "The internal entity unique identifier"
   goid: ID
+  "The guid for this service, if none provided, assigned at creation"
+  guid: ID
   "The folder path where to create this service.  If the path does not exist, it will be created"
   folderPath: NonEmptyString!
   "The name of the service"


### PR DESCRIPTION
v11.0 CR01 support
- schema files
- updated queries
- introduced a new query for supporting administrative entities
- - **_sysinfo_** for querying them
- - - `graphman.bat export --using sysinfo`
- - **_sysinfo-mutation_** for mutating them
- - - `graphman.bat import --using sysinfo-mutation --input some-input.json`
- updated default **_schemaVersion_** (to **v11.0-CR01**)

With this, graphman-client (by default) works with v11.0-CR01 schemas. 
If user wants to make it work with v10.1-CR03,
- provide **_--schemaVersion v10.1-CR03 CLI_** parameter (OR) update the _**schemaVersion**_ in the **_graphman.configuration_** file
