### PR TITLE
NORALLY: graphman-client - fixing the issue with overriding the boolean type configuration parameter

### DIFF
--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -70,7 +70,7 @@ module.exports = {
             path: url.pathname || '/graphman',
             protocol: url.protocol,
             method: 'POST',
-            rejectUnauthorized: gateway.rejectUnauthorized,
+            rejectUnauthorized: (gateway.rejectUnauthorized || true).toString() === 'true',
             headers: headers,
             body: body || {}
         };

--- a/graphman-client/modules/graphman.js
+++ b/graphman-client/modules/graphman.js
@@ -64,13 +64,17 @@ module.exports = {
             headers['l7-passphrase'] = gateway.passphrase;
         }
 
+        if (gateway.rejectUnauthorized === undefined) {
+            gateway.rejectUnauthorized = true;
+        }
+
         const req = {
             host: url.hostname,
             port: url.port || 443,
             path: url.pathname || '/graphman',
             protocol: url.protocol,
             method: 'POST',
-            rejectUnauthorized: (gateway.rejectUnauthorized || true).toString() === 'true',
+            rejectUnauthorized: gateway.rejectUnauthorized.toString() === 'true',
             headers: headers,
             body: body || {}
         };


### PR DESCRIPTION
Command line parameters are made available as strings. They need to be coerced as per the use. 
One of the gateway configuration parameter (**_rejectUnauthorized_**) is Boolean type, this can be overridden using CLI parameter (i.e., _--sourceGateway.rejectUnauthorized_ or _--targetGateway.rejectUnauthorized_). 

This change ensures to use the supplied value properly.
